### PR TITLE
Adding missing license link

### DIFF
--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -27,12 +27,12 @@
     "content": {
         "details": {
             "path": "details.md"
+        },
+        "license": {
+            "path": "LICENSE"
         }
     },
     "links": {
-        "getstarted": {
-            "uri": "https://aka.ms/open-in-excel"
-        },
         "learn": {
             "uri": "https://aka.ms/devopsexcel"
         },


### PR DESCRIPTION
This pull request includes changes to the `azure-devops-extension.json` file to update the content and links sections. The most important changes are:

Content updates:
* Added a new license section with a path to the `LICENSE` file.

Link updates:
* Removed the "getstarted" link that pointed to "https://aka.ms/open-in-excel".