### PR TITLE
fix: use npm proxy registry for package resolution

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://packagefeedproxy.microsoft.io/npm/

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         },
         "node_modules/@ampproject/remapping": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@ampproject/remapping/-/remapping-2.3.0.tgz",
             "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
             "dev": true,
             "dependencies": {
@@ -56,7 +56,7 @@
         },
         "node_modules/@babel/code-frame": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/code-frame/-/code-frame-7.27.1.tgz",
             "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dev": true,
             "license": "MIT",
@@ -71,7 +71,7 @@
         },
         "node_modules/@babel/compat-data": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/compat-data/-/compat-data-7.28.0.tgz",
             "integrity": "sha512-60X7qkglvrap8mn1lh2ebxXdZYtUcpd7gsmy9kLaBJ4i/WdY8PqTSdxyA8qraikqKQK5C1KRBKXqznrVapyNaw==",
             "dev": true,
             "license": "MIT",
@@ -81,7 +81,7 @@
         },
         "node_modules/@babel/core": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/core/-/core-7.28.0.tgz",
             "integrity": "sha512-UlLAnTPrFdNGoFtbSXwcGFQBtQZJCNjaN6hQNP3UPvuNXT1i82N26KL3dZeIpNalWywr9IuQuncaAfUaS1g6sQ==",
             "dev": true,
             "license": "MIT",
@@ -112,7 +112,7 @@
         },
         "node_modules/@babel/generator": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/generator/-/generator-7.28.0.tgz",
             "integrity": "sha512-lJjzvrbEeWrhB4P3QBsH7tey117PjLZnDbLiQEKjQ/fNJTjuq4HSqgFA+UNSwZT8D7dxxbnuSBMsa1lrWzKlQg==",
             "dev": true,
             "license": "MIT",
@@ -129,7 +129,7 @@
         },
         "node_modules/@babel/helper-annotate-as-pure": {
             "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
             "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
             "dev": true,
             "license": "MIT",
@@ -142,7 +142,7 @@
         },
         "node_modules/@babel/helper-compilation-targets": {
             "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
             "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
             "dev": true,
             "license": "MIT",
@@ -159,7 +159,7 @@
         },
         "node_modules/@babel/helper-create-class-features-plugin": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.27.1.tgz",
             "integrity": "sha512-QwGAmuvM17btKU5VqXfb+Giw4JcN0hjuufz3DYnpeVDvZLAObloM77bhMXiqry3Iio+Ai4phVRDwl6WU10+r5A==",
             "dev": true,
             "license": "MIT",
@@ -181,7 +181,7 @@
         },
         "node_modules/@babel/helper-create-regexp-features-plugin": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.27.1.tgz",
             "integrity": "sha512-uVDC72XVf8UbrH5qQTc18Agb8emwjTiZrQE11Nv3CuBEZmVvTwwE9CBUEvHku06gQCAyYf8Nv6ja1IN+6LMbxQ==",
             "dev": true,
             "license": "MIT",
@@ -199,7 +199,7 @@
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
             "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
             "integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
             "dev": true,
             "license": "MIT",
@@ -216,7 +216,7 @@
         },
         "node_modules/@babel/helper-globals": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
             "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
             "dev": true,
             "license": "MIT",
@@ -226,7 +226,7 @@
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.27.1.tgz",
             "integrity": "sha512-E5chM8eWjTp/aNoVpcbfM7mLxu9XGLWYise2eBKGQomAk/Mb4XoxyqXTZbuTohbsl8EKqdlMhnDI2CCLfcs9wA==",
             "dev": true,
             "license": "MIT",
@@ -240,7 +240,7 @@
         },
         "node_modules/@babel/helper-module-imports": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
             "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
             "dev": true,
             "license": "MIT",
@@ -254,7 +254,7 @@
         },
         "node_modules/@babel/helper-module-transforms": {
             "version": "7.27.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-module-transforms/-/helper-module-transforms-7.27.3.tgz",
             "integrity": "sha512-dSOvYwvyLsWBeIRyOeHXp5vPj5l1I011r52FM1+r1jCERv+aFXYk4whgQccYEGYxK2H3ZAIA8nuPkQ0HaUo3qg==",
             "dev": true,
             "license": "MIT",
@@ -272,7 +272,7 @@
         },
         "node_modules/@babel/helper-optimise-call-expression": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
             "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
             "dev": true,
             "license": "MIT",
@@ -285,7 +285,7 @@
         },
         "node_modules/@babel/helper-plugin-utils": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
             "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
             "dev": true,
             "license": "MIT",
@@ -295,7 +295,7 @@
         },
         "node_modules/@babel/helper-remap-async-to-generator": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.27.1.tgz",
             "integrity": "sha512-7fiA521aVw8lSPeI4ZOD3vRFkoqkJcS+z4hFo82bFSH/2tNd6eJ5qCVMS5OzDmZh/kaHQeBaeyxK6wljcPtveA==",
             "dev": true,
             "license": "MIT",
@@ -313,7 +313,7 @@
         },
         "node_modules/@babel/helper-replace-supers": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
             "integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
             "dev": true,
             "license": "MIT",
@@ -331,7 +331,7 @@
         },
         "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
             "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
             "dev": true,
             "license": "MIT",
@@ -345,7 +345,7 @@
         },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
             "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true,
             "license": "MIT",
@@ -355,7 +355,7 @@
         },
         "node_modules/@babel/helper-validator-identifier": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
             "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
             "dev": true,
             "license": "MIT",
@@ -365,7 +365,7 @@
         },
         "node_modules/@babel/helper-validator-option": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
             "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "dev": true,
             "license": "MIT",
@@ -375,7 +375,7 @@
         },
         "node_modules/@babel/helper-wrap-function": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helper-wrap-function/-/helper-wrap-function-7.27.1.tgz",
             "integrity": "sha512-NFJK2sHUvrjo8wAU/nQTWU890/zB2jj0qBcCbZbbf+005cAsv6tMjXz31fBign6M5ov1o0Bllu+9nbqkfsjjJQ==",
             "dev": true,
             "license": "MIT",
@@ -390,7 +390,7 @@
         },
         "node_modules/@babel/helpers": {
             "version": "7.28.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/helpers/-/helpers-7.28.2.tgz",
             "integrity": "sha512-/V9771t+EgXz62aCcyofnQhGM8DQACbRhvzKFsXKC9QM+5MadF8ZmIm0crDMaz3+o0h0zXfJnd4EhbYbxsrcFw==",
             "dev": true,
             "license": "MIT",
@@ -404,7 +404,7 @@
         },
         "node_modules/@babel/parser": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/parser/-/parser-7.28.0.tgz",
             "integrity": "sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==",
             "dev": true,
             "license": "MIT",
@@ -420,7 +420,7 @@
         },
         "node_modules/@babel/plugin-bugfix-firefox-class-in-computed-class-key": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-bugfix-firefox-class-in-computed-class-key/-/plugin-bugfix-firefox-class-in-computed-class-key-7.27.1.tgz",
             "integrity": "sha512-QPG3C9cCVRQLxAVwmefEmwdTanECuUBMQZ/ym5kiw3XKCGA7qkuQLcjWWHcrD/GKbn/WmJwaezfuuAOcyKlRPA==",
             "dev": true,
             "license": "MIT",
@@ -437,7 +437,7 @@
         },
         "node_modules/@babel/plugin-bugfix-safari-class-field-initializer-scope": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-bugfix-safari-class-field-initializer-scope/-/plugin-bugfix-safari-class-field-initializer-scope-7.27.1.tgz",
             "integrity": "sha512-qNeq3bCKnGgLkEXUuFry6dPlGfCdQNZbn7yUAPCInwAJHMU7THJfrBSozkcWq5sNM6RcF3S8XyQL2A52KNR9IA==",
             "dev": true,
             "license": "MIT",
@@ -453,7 +453,7 @@
         },
         "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.27.1.tgz",
             "integrity": "sha512-g4L7OYun04N1WyqMNjldFwlfPCLVkgB54A/YCXICZYBsvJJE3kByKv9c9+R/nAfmIfjl2rKYLNyMHboYbZaWaA==",
             "dev": true,
             "license": "MIT",
@@ -469,7 +469,7 @@
         },
         "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.27.1.tgz",
             "integrity": "sha512-oO02gcONcD5O1iTLi/6frMJBIwWEHceWGSGqrpCmEL8nogiS6J9PBlE48CaK20/Jx1LuRml9aDftLgdjXT8+Cw==",
             "dev": true,
             "license": "MIT",
@@ -487,7 +487,7 @@
         },
         "node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.27.1.tgz",
             "integrity": "sha512-6BpaYGDavZqkI6yT+KSPdpZFfpnd68UKXbcjI9pJ13pvHhPrCKWOOLp+ysvMeA+DxnhuPpgIaRpxRxo5A9t5jw==",
             "dev": true,
             "license": "MIT",
@@ -504,7 +504,7 @@
         },
         "node_modules/@babel/plugin-proposal-private-property-in-object": {
             "version": "7.21.0-placeholder-for-preset-env.2",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
             "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
             "dev": true,
             "engines": {
@@ -516,7 +516,7 @@
         },
         "node_modules/@babel/plugin-syntax-import-assertions": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
             "integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
             "dev": true,
             "license": "MIT",
@@ -532,7 +532,7 @@
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
             "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
             "dev": true,
             "license": "MIT",
@@ -548,7 +548,7 @@
         },
         "node_modules/@babel/plugin-syntax-jsx": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
             "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
             "dev": true,
             "license": "MIT",
@@ -564,7 +564,7 @@
         },
         "node_modules/@babel/plugin-syntax-typescript": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
             "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
             "dev": true,
             "license": "MIT",
@@ -580,7 +580,7 @@
         },
         "node_modules/@babel/plugin-syntax-unicode-sets-regex": {
             "version": "7.18.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-syntax-unicode-sets-regex/-/plugin-syntax-unicode-sets-regex-7.18.6.tgz",
             "integrity": "sha512-727YkEAPwSIQTv5im8QHz3upqp92JTWhidIC81Tdx4VJYIte/VndKf1qKrfnnhPLiPghStWfvC/iFaMCQu7Nqg==",
             "dev": true,
             "dependencies": {
@@ -596,7 +596,7 @@
         },
         "node_modules/@babel/plugin-transform-arrow-functions": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.27.1.tgz",
             "integrity": "sha512-8Z4TGic6xW70FKThA5HYEKKyBpOOsucTOD1DjU3fZxDg+K3zBJcXMFnt/4yQiZnf5+MiOMSXQ9PaEK/Ilh1DeA==",
             "dev": true,
             "license": "MIT",
@@ -612,7 +612,7 @@
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
             "integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
             "dev": true,
             "license": "MIT",
@@ -630,7 +630,7 @@
         },
         "node_modules/@babel/plugin-transform-async-to-generator": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
             "integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
             "dev": true,
             "license": "MIT",
@@ -648,7 +648,7 @@
         },
         "node_modules/@babel/plugin-transform-block-scoped-functions": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.27.1.tgz",
             "integrity": "sha512-cnqkuOtZLapWYZUYM5rVIdv1nXYuFVIltZ6ZJ7nIj585QsjKM5dhL2Fu/lICXZ1OyIAFc7Qy+bvDAtTXqGrlhg==",
             "dev": true,
             "license": "MIT",
@@ -664,7 +664,7 @@
         },
         "node_modules/@babel/plugin-transform-block-scoping": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.0.tgz",
             "integrity": "sha512-gKKnwjpdx5sER/wl0WN0efUBFzF/56YZO0RJrSYP4CljXnP31ByY7fol89AzomdlLNzI36AvOTmYHsnZTCkq8Q==",
             "dev": true,
             "license": "MIT",
@@ -680,7 +680,7 @@
         },
         "node_modules/@babel/plugin-transform-class-properties": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
             "integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
             "dev": true,
             "license": "MIT",
@@ -697,7 +697,7 @@
         },
         "node_modules/@babel/plugin-transform-class-static-block": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.27.1.tgz",
             "integrity": "sha512-s734HmYU78MVzZ++joYM+NkJusItbdRcbm+AGRgJCt3iA+yux0QpD9cBVdz3tKyrjVYWRl7j0mHSmv4lhV0aoA==",
             "dev": true,
             "license": "MIT",
@@ -714,7 +714,7 @@
         },
         "node_modules/@babel/plugin-transform-classes": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.0.tgz",
             "integrity": "sha512-IjM1IoJNw72AZFlj33Cu8X0q2XK/6AaVC3jQu+cgQ5lThWD5ajnuUAml80dqRmOhmPkTH8uAwnpMu9Rvj0LTRA==",
             "dev": true,
             "license": "MIT",
@@ -735,7 +735,7 @@
         },
         "node_modules/@babel/plugin-transform-computed-properties": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
             "integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
             "dev": true,
             "license": "MIT",
@@ -752,7 +752,7 @@
         },
         "node_modules/@babel/plugin-transform-destructuring": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.28.0.tgz",
             "integrity": "sha512-v1nrSMBiKcodhsyJ4Gf+Z0U/yawmJDBOTpEB3mcQY52r9RIyPneGyAS/yM6seP/8I+mWI3elOMtT5dB8GJVs+A==",
             "dev": true,
             "license": "MIT",
@@ -769,7 +769,7 @@
         },
         "node_modules/@babel/plugin-transform-dotall-regex": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
             "integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
             "dev": true,
             "license": "MIT",
@@ -786,7 +786,7 @@
         },
         "node_modules/@babel/plugin-transform-duplicate-keys": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.27.1.tgz",
             "integrity": "sha512-MTyJk98sHvSs+cvZ4nOauwTTG1JeonDjSGvGGUNHreGQns+Mpt6WX/dVzWBHgg+dYZhkC4X+zTDfkTU+Vy9y7Q==",
             "dev": true,
             "license": "MIT",
@@ -802,7 +802,7 @@
         },
         "node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
             "integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
             "dev": true,
             "license": "MIT",
@@ -819,7 +819,7 @@
         },
         "node_modules/@babel/plugin-transform-dynamic-import": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
             "integrity": "sha512-MHzkWQcEmjzzVW9j2q8LGjwGWpG2mjwaaB0BNQwst3FIjqsg8Ct/mIZlvSPJvfi9y2AC8mi/ktxbFVL9pZ1I4A==",
             "dev": true,
             "license": "MIT",
@@ -835,7 +835,7 @@
         },
         "node_modules/@babel/plugin-transform-explicit-resource-management": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.0.tgz",
             "integrity": "sha512-K8nhUcn3f6iB+P3gwCv/no7OdzOZQcKchW6N389V6PD8NUWKZHzndOd9sPDVbMoBsbmjMqlB4L9fm+fEFNVlwQ==",
             "dev": true,
             "license": "MIT",
@@ -852,7 +852,7 @@
         },
         "node_modules/@babel/plugin-transform-exponentiation-operator": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.27.1.tgz",
             "integrity": "sha512-uspvXnhHvGKf2r4VVtBpeFnuDWsJLQ6MF6lGJLC89jBR1uoVeqM416AZtTuhTezOfgHicpJQmoD5YUakO/YmXQ==",
             "dev": true,
             "license": "MIT",
@@ -868,7 +868,7 @@
         },
         "node_modules/@babel/plugin-transform-export-namespace-from": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-export-namespace-from/-/plugin-transform-export-namespace-from-7.27.1.tgz",
             "integrity": "sha512-tQvHWSZ3/jH2xuq/vZDy0jNn+ZdXJeM8gHvX4lnJmsc3+50yPlWdZXIc5ay+umX+2/tJIqHqiEqcJvxlmIvRvQ==",
             "dev": true,
             "license": "MIT",
@@ -884,7 +884,7 @@
         },
         "node_modules/@babel/plugin-transform-for-of": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.27.1.tgz",
             "integrity": "sha512-BfbWFFEJFQzLCQ5N8VocnCtA8J1CLkNTe2Ms2wocj75dd6VpiqS5Z5quTYcUoo4Yq+DN0rtikODccuv7RU81sw==",
             "dev": true,
             "license": "MIT",
@@ -901,7 +901,7 @@
         },
         "node_modules/@babel/plugin-transform-function-name": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.27.1.tgz",
             "integrity": "sha512-1bQeydJF9Nr1eBCMMbC+hdwmRlsv5XYOMu03YSWFwNs0HsAmtSxxF1fyuYPqemVldVyFmlCU7w8UE14LupUSZQ==",
             "dev": true,
             "license": "MIT",
@@ -919,7 +919,7 @@
         },
         "node_modules/@babel/plugin-transform-json-strings": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
             "integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
             "dev": true,
             "license": "MIT",
@@ -935,7 +935,7 @@
         },
         "node_modules/@babel/plugin-transform-literals": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-literals/-/plugin-transform-literals-7.27.1.tgz",
             "integrity": "sha512-0HCFSepIpLTkLcsi86GG3mTUzxV5jpmbv97hTETW3yzrAij8aqlD36toB1D0daVFJM8NK6GvKO0gslVQmm+zZA==",
             "dev": true,
             "license": "MIT",
@@ -951,7 +951,7 @@
         },
         "node_modules/@babel/plugin-transform-logical-assignment-operators": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.27.1.tgz",
             "integrity": "sha512-SJvDs5dXxiae4FbSL1aBJlG4wvl594N6YEVVn9e3JGulwioy6z3oPjx/sQBO3Y4NwUu5HNix6KJ3wBZoewcdbw==",
             "dev": true,
             "license": "MIT",
@@ -967,7 +967,7 @@
         },
         "node_modules/@babel/plugin-transform-member-expression-literals": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.27.1.tgz",
             "integrity": "sha512-hqoBX4dcZ1I33jCSWcXrP+1Ku7kdqXf1oeah7ooKOIiAdKQ+uqftgCFNOSzA5AMS2XIHEYeGFg4cKRCdpxzVOQ==",
             "dev": true,
             "license": "MIT",
@@ -983,7 +983,7 @@
         },
         "node_modules/@babel/plugin-transform-modules-amd": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.27.1.tgz",
             "integrity": "sha512-iCsytMg/N9/oFq6n+gFTvUYDZQOMK5kEdeYxmxt91fcJGycfxVP9CnrxoliM0oumFERba2i8ZtwRUCMhvP1LnA==",
             "dev": true,
             "license": "MIT",
@@ -1000,7 +1000,7 @@
         },
         "node_modules/@babel/plugin-transform-modules-commonjs": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
             "integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
             "dev": true,
             "license": "MIT",
@@ -1017,7 +1017,7 @@
         },
         "node_modules/@babel/plugin-transform-modules-systemjs": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.27.1.tgz",
             "integrity": "sha512-w5N1XzsRbc0PQStASMksmUeqECuzKuTJer7kFagK8AXgpCMkeDMO5S+aaFb7A51ZYDF7XI34qsTX+fkHiIm5yA==",
             "dev": true,
             "license": "MIT",
@@ -1036,7 +1036,7 @@
         },
         "node_modules/@babel/plugin-transform-modules-umd": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.27.1.tgz",
             "integrity": "sha512-iQBE/xC5BV1OxJbp6WG7jq9IWiD+xxlZhLrdwpPkTX3ydmXdvoCpyfJN7acaIBZaOqTfr76pgzqBJflNbeRK+w==",
             "dev": true,
             "license": "MIT",
@@ -1053,7 +1053,7 @@
         },
         "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
             "integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
             "dev": true,
             "license": "MIT",
@@ -1070,7 +1070,7 @@
         },
         "node_modules/@babel/plugin-transform-new-target": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.27.1.tgz",
             "integrity": "sha512-f6PiYeqXQ05lYq3TIfIDu/MtliKUbNwkGApPUvyo6+tc7uaR4cPjPe7DFPr15Uyycg2lZU6btZ575CuQoYh7MQ==",
             "dev": true,
             "license": "MIT",
@@ -1086,7 +1086,7 @@
         },
         "node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
             "integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
             "dev": true,
             "license": "MIT",
@@ -1102,7 +1102,7 @@
         },
         "node_modules/@babel/plugin-transform-numeric-separator": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
             "integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
             "dev": true,
             "license": "MIT",
@@ -1118,7 +1118,7 @@
         },
         "node_modules/@babel/plugin-transform-object-rest-spread": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.0.tgz",
             "integrity": "sha512-9VNGikXxzu5eCiQjdE4IZn8sb9q7Xsk5EXLDBKUYg1e/Tve8/05+KJEtcxGxAgCY5t/BpKQM+JEL/yT4tvgiUA==",
             "dev": true,
             "license": "MIT",
@@ -1138,7 +1138,7 @@
         },
         "node_modules/@babel/plugin-transform-object-super": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.27.1.tgz",
             "integrity": "sha512-SFy8S9plRPbIcxlJ8A6mT/CxFdJx/c04JEctz4jf8YZaVS2px34j7NXRrlGlHkN/M2gnpL37ZpGRGVFLd3l8Ng==",
             "dev": true,
             "license": "MIT",
@@ -1155,7 +1155,7 @@
         },
         "node_modules/@babel/plugin-transform-optional-catch-binding": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
             "integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
             "dev": true,
             "license": "MIT",
@@ -1171,7 +1171,7 @@
         },
         "node_modules/@babel/plugin-transform-optional-chaining": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.27.1.tgz",
             "integrity": "sha512-BQmKPPIuc8EkZgNKsv0X4bPmOoayeu4F1YCwx2/CfmDSXDbp7GnzlUH+/ul5VGfRg1AoFPsrIThlEBj2xb4CAg==",
             "dev": true,
             "license": "MIT",
@@ -1188,7 +1188,7 @@
         },
         "node_modules/@babel/plugin-transform-parameters": {
             "version": "7.27.7",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.27.7.tgz",
             "integrity": "sha512-qBkYTYCb76RRxUM6CcZA5KRu8K4SM8ajzVeUgVdMVO9NN9uI/GaVmBg/WKJJGnNokV9SY8FxNOVWGXzqzUidBg==",
             "dev": true,
             "license": "MIT",
@@ -1204,7 +1204,7 @@
         },
         "node_modules/@babel/plugin-transform-private-methods": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
             "integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
             "dev": true,
             "license": "MIT",
@@ -1221,7 +1221,7 @@
         },
         "node_modules/@babel/plugin-transform-private-property-in-object": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
             "integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
             "dev": true,
             "license": "MIT",
@@ -1239,7 +1239,7 @@
         },
         "node_modules/@babel/plugin-transform-property-literals": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.27.1.tgz",
             "integrity": "sha512-oThy3BCuCha8kDZ8ZkgOg2exvPYUlprMukKQXI1r1pJ47NCvxfkEy8vK+r/hT9nF0Aa4H1WUPZZjHTFtAhGfmQ==",
             "dev": true,
             "license": "MIT",
@@ -1255,7 +1255,7 @@
         },
         "node_modules/@babel/plugin-transform-react-display-name": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.27.1.tgz",
             "integrity": "sha512-p9+Vl3yuHPmkirRrg021XiP+EETmPMQTLr6Ayjj85RLNEbb3Eya/4VI0vAdzQG9SEAl2Lnt7fy5lZyMzjYoZQQ==",
             "dev": true,
             "license": "MIT",
@@ -1271,7 +1271,7 @@
         },
         "node_modules/@babel/plugin-transform-react-jsx": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
             "integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
             "dev": true,
             "license": "MIT",
@@ -1291,7 +1291,7 @@
         },
         "node_modules/@babel/plugin-transform-react-jsx-development": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.27.1.tgz",
             "integrity": "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q==",
             "dev": true,
             "license": "MIT",
@@ -1307,7 +1307,7 @@
         },
         "node_modules/@babel/plugin-transform-react-pure-annotations": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.27.1.tgz",
             "integrity": "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA==",
             "dev": true,
             "license": "MIT",
@@ -1324,7 +1324,7 @@
         },
         "node_modules/@babel/plugin-transform-regenerator": {
             "version": "7.28.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.1.tgz",
             "integrity": "sha512-P0QiV/taaa3kXpLY+sXla5zec4E+4t4Aqc9ggHlfZ7a2cp8/x/Gv08jfwEtn9gnnYIMvHx6aoOZ8XJL8eU71Dg==",
             "dev": true,
             "license": "MIT",
@@ -1340,7 +1340,7 @@
         },
         "node_modules/@babel/plugin-transform-regexp-modifiers": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.27.1.tgz",
             "integrity": "sha512-TtEciroaiODtXvLZv4rmfMhkCv8jx3wgKpL68PuiPh2M4fvz5jhsA7697N1gMvkvr/JTF13DrFYyEbY9U7cVPA==",
             "dev": true,
             "license": "MIT",
@@ -1357,7 +1357,7 @@
         },
         "node_modules/@babel/plugin-transform-reserved-words": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.27.1.tgz",
             "integrity": "sha512-V2ABPHIJX4kC7HegLkYoDpfg9PVmuWy/i6vUM5eGK22bx4YVFD3M5F0QQnWQoDs6AGsUWTVOopBiMFQgHaSkVw==",
             "dev": true,
             "license": "MIT",
@@ -1373,7 +1373,7 @@
         },
         "node_modules/@babel/plugin-transform-shorthand-properties": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
             "integrity": "sha512-N/wH1vcn4oYawbJ13Y/FxcQrWk63jhfNa7jef0ih7PHSIHX2LB7GWE1rkPrOnka9kwMxb6hMl19p7lidA+EHmQ==",
             "dev": true,
             "license": "MIT",
@@ -1389,7 +1389,7 @@
         },
         "node_modules/@babel/plugin-transform-spread": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
             "integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
             "dev": true,
             "license": "MIT",
@@ -1406,7 +1406,7 @@
         },
         "node_modules/@babel/plugin-transform-sticky-regex": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.27.1.tgz",
             "integrity": "sha512-lhInBO5bi/Kowe2/aLdBAawijx+q1pQzicSgnkB6dUPc1+RC8QmJHKf2OjvU+NZWitguJHEaEmbV6VWEouT58g==",
             "dev": true,
             "license": "MIT",
@@ -1422,7 +1422,7 @@
         },
         "node_modules/@babel/plugin-transform-template-literals": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.27.1.tgz",
             "integrity": "sha512-fBJKiV7F2DxZUkg5EtHKXQdbsbURW3DZKQUWphDum0uRP6eHGGa/He9mc0mypL680pb+e/lDIthRohlv8NCHkg==",
             "dev": true,
             "license": "MIT",
@@ -1438,7 +1438,7 @@
         },
         "node_modules/@babel/plugin-transform-typeof-symbol": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
             "integrity": "sha512-RiSILC+nRJM7FY5srIyc4/fGIwUhyDuuBSdWn4y6yT6gm652DpCHZjIipgn6B7MQ1ITOUnAKWixEUjQRIBIcLw==",
             "dev": true,
             "license": "MIT",
@@ -1454,7 +1454,7 @@
         },
         "node_modules/@babel/plugin-transform-typescript": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.27.1.tgz",
             "integrity": "sha512-Q5sT5+O4QUebHdbwKedFBEwRLb02zJ7r4A5Gg2hUoLuU3FjdMcyqcywqUrLCaDsFCxzokf7u9kuy7qz51YUuAg==",
             "dev": true,
             "license": "MIT",
@@ -1474,7 +1474,7 @@
         },
         "node_modules/@babel/plugin-transform-unicode-escapes": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.27.1.tgz",
             "integrity": "sha512-Ysg4v6AmF26k9vpfFuTZg8HRfVWzsh1kVfowA23y9j/Gu6dOuahdUVhkLqpObp3JIv27MLSii6noRnuKN8H0Mg==",
             "dev": true,
             "license": "MIT",
@@ -1490,7 +1490,7 @@
         },
         "node_modules/@babel/plugin-transform-unicode-property-regex": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
             "integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
             "dev": true,
             "license": "MIT",
@@ -1507,7 +1507,7 @@
         },
         "node_modules/@babel/plugin-transform-unicode-regex": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.27.1.tgz",
             "integrity": "sha512-xvINq24TRojDuyt6JGtHmkVkrfVV3FPT16uytxImLeBZqW3/H52yN+kM1MGuyPkIQxrzKwPHs5U/MP3qKyzkGw==",
             "dev": true,
             "license": "MIT",
@@ -1524,7 +1524,7 @@
         },
         "node_modules/@babel/plugin-transform-unicode-sets-regex": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
             "integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
             "dev": true,
             "license": "MIT",
@@ -1541,7 +1541,7 @@
         },
         "node_modules/@babel/preset-env": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/preset-env/-/preset-env-7.28.0.tgz",
             "integrity": "sha512-VmaxeGOwuDqzLl5JUkIRM1X2Qu2uKGxHEQWh+cvvbl7JuJRgKGJSfsEF/bUaxFhJl/XAyxBe7q7qSuTbKFuCyg==",
             "dev": true,
             "license": "MIT",
@@ -1626,7 +1626,7 @@
         },
         "node_modules/@babel/preset-modules": {
             "version": "0.1.6-no-external-plugins",
-            "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/preset-modules/-/preset-modules-0.1.6-no-external-plugins.tgz",
             "integrity": "sha512-HrcgcIESLm9aIR842yhJ5RWan/gebQUJ6E/E5+rf0y9o6oj7w0Br+sWuL6kEQ/o/AdfvR1Je9jG18/gnpwjEyA==",
             "dev": true,
             "dependencies": {
@@ -1640,7 +1640,7 @@
         },
         "node_modules/@babel/preset-react": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/preset-react/-/preset-react-7.27.1.tgz",
             "integrity": "sha512-oJHWh2gLhU9dW9HHr42q0cI0/iHHXTLGe39qvpAZZzagHy0MzYLCnCVV0symeRvzmjHyVU7mw2K06E6u/JwbhA==",
             "dev": true,
             "license": "MIT",
@@ -1661,7 +1661,7 @@
         },
         "node_modules/@babel/preset-typescript": {
             "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/preset-typescript/-/preset-typescript-7.27.1.tgz",
             "integrity": "sha512-l7WfQfX0WK4M0v2RudjuQK4u99BS6yLHYEmdtVPP7lKV013zr9DygFuWNlnbvQ9LR+LS0Egz/XAvGx5U9MX0fQ==",
             "dev": true,
             "license": "MIT",
@@ -1681,7 +1681,7 @@
         },
         "node_modules/@babel/template": {
             "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/template/-/template-7.27.2.tgz",
             "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
             "dev": true,
             "license": "MIT",
@@ -1696,7 +1696,7 @@
         },
         "node_modules/@babel/traverse": {
             "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/traverse/-/traverse-7.28.0.tgz",
             "integrity": "sha512-mGe7UK5wWyh0bKRfupsUchrQGqvDbZDbKJw+kcRGSmdHVYrv+ltd0pnpDTVpiTqnaBru9iEvA8pz8W46v0Amwg==",
             "dev": true,
             "license": "MIT",
@@ -1715,7 +1715,7 @@
         },
         "node_modules/@babel/types": {
             "version": "7.28.2",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@babel/types/-/types-7.28.2.tgz",
             "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
             "dev": true,
             "license": "MIT",
@@ -1729,7 +1729,7 @@
         },
         "node_modules/@discoveryjs/json-ext": {
             "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
             "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
             "dev": true,
             "engines": {
@@ -1738,7 +1738,7 @@
         },
         "node_modules/@isaacs/balanced-match": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
             "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
             "dev": true,
             "license": "MIT",
@@ -1748,7 +1748,7 @@
         },
         "node_modules/@isaacs/brace-expansion": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
             "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
             "dev": true,
             "license": "MIT",
@@ -1761,7 +1761,7 @@
         },
         "node_modules/@isaacs/cliui": {
             "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@isaacs/cliui/-/cliui-8.0.2.tgz",
             "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
             "dev": true,
             "license": "ISC",
@@ -1779,7 +1779,7 @@
         },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.12",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.12.tgz",
             "integrity": "sha512-OuLGC46TjB5BbN1dH8JULVVZY4WTdkF7tV9Ys6wLL1rubZnCMstOhNHueU5bLCrnRuDhKPDM4g6sw4Bel5Gzqg==",
             "dev": true,
             "license": "MIT",
@@ -1790,7 +1790,7 @@
         },
         "node_modules/@jridgewell/resolve-uri": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
             "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "engines": {
@@ -1799,7 +1799,7 @@
         },
         "node_modules/@jridgewell/source-map": {
             "version": "0.3.6",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/source-map/-/source-map-0.3.6.tgz",
             "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
             "dev": true,
             "dependencies": {
@@ -1809,13 +1809,13 @@
         },
         "node_modules/@jridgewell/sourcemap-codec": {
             "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
             "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.29",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
             "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
             "dev": true,
             "license": "MIT",
@@ -1826,7 +1826,7 @@
         },
         "node_modules/@jsonjoy.com/base64": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
             "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
             "dev": true,
             "engines": {
@@ -1842,7 +1842,7 @@
         },
         "node_modules/@jsonjoy.com/json-pack": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/json-pack/-/json-pack-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jsonjoy.com/json-pack/-/json-pack-1.1.1.tgz",
             "integrity": "sha512-osjeBqMJ2lb/j/M8NCPjs1ylqWIcTRTycIhVB5pt6LgzgeRSb0YRZ7j9RfA8wIUrsr/medIuhVyonXRZWLyfdw==",
             "dev": true,
             "dependencies": {
@@ -1864,7 +1864,7 @@
         },
         "node_modules/@jsonjoy.com/util": {
             "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@jsonjoy.com/util/-/util-1.5.0.tgz",
             "integrity": "sha512-ojoNsrIuPI9g6o8UxhraZQSyF2ByJanAY4cTFbc8Mf2AXEF4aQRGY1dJxyJpuyav8r9FGflEt/Ff3u5Nt6YMPA==",
             "dev": true,
             "engines": {
@@ -1880,13 +1880,13 @@
         },
         "node_modules/@leichtgewicht/ip-codec": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
             "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
             "dev": true
         },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.6.1.tgz",
             "integrity": "sha512-95DXXJxNkpYu+sqmpDp7vbw9JCyiNpHuCsvuMuOgVFrKQlwEIn9Y1+NNIQJq+zFL+eWyxw6htthB5CtdwJupNA==",
             "dev": true,
             "license": "MIT",
@@ -1934,7 +1934,7 @@
         },
         "node_modules/@types/body-parser": {
             "version": "1.19.5",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/body-parser/-/body-parser-1.19.5.tgz",
             "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
             "dev": true,
             "dependencies": {
@@ -1944,7 +1944,7 @@
         },
         "node_modules/@types/bonjour": {
             "version": "3.5.13",
-            "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.13.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/bonjour/-/bonjour-3.5.13.tgz",
             "integrity": "sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==",
             "dev": true,
             "dependencies": {
@@ -1953,7 +1953,7 @@
         },
         "node_modules/@types/connect": {
             "version": "3.4.38",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/connect/-/connect-3.4.38.tgz",
             "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
             "dev": true,
             "dependencies": {
@@ -1962,7 +1962,7 @@
         },
         "node_modules/@types/connect-history-api-fallback": {
             "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.4.tgz",
             "integrity": "sha512-n6Cr2xS1h4uAulPRdlw6Jl6s1oG8KrVilPN2yUITEs+K48EzMJJ3W1xy8K5eWuFvjp3R74AOIGSmp2UfBJ8HFw==",
             "dev": true,
             "dependencies": {
@@ -1972,7 +1972,7 @@
         },
         "node_modules/@types/eslint": {
             "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/eslint/-/eslint-9.6.1.tgz",
             "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "dependencies": {
@@ -1982,7 +1982,7 @@
         },
         "node_modules/@types/eslint-scope": {
             "version": "3.7.7",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
             "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
             "dev": true,
             "dependencies": {
@@ -1992,14 +1992,14 @@
         },
         "node_modules/@types/estree": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/express": {
             "version": "4.17.21",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.21.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/express/-/express-4.17.21.tgz",
             "integrity": "sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==",
             "dev": true,
             "dependencies": {
@@ -2011,7 +2011,7 @@
         },
         "node_modules/@types/express-serve-static-core": {
             "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
             "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
             "dev": true,
             "dependencies": {
@@ -2023,7 +2023,7 @@
         },
         "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
             "version": "4.19.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
             "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
             "dev": true,
             "dependencies": {
@@ -2035,13 +2035,13 @@
         },
         "node_modules/@types/http-errors": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/http-errors/-/http-errors-2.0.4.tgz",
             "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
             "dev": true
         },
         "node_modules/@types/http-proxy": {
             "version": "1.17.15",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.15.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/http-proxy/-/http-proxy-1.17.15.tgz",
             "integrity": "sha512-25g5atgiVNTIv0LBDTg1H74Hvayx0ajtJPLLcYE3whFv75J0pWNtOBzaXJQgDTmrX1bx5U9YC2w/n65BN1HwRQ==",
             "dev": true,
             "dependencies": {
@@ -2050,19 +2050,19 @@
         },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true
         },
         "node_modules/@types/mime": {
             "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/mime/-/mime-1.3.5.tgz",
             "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
             "dev": true
         },
         "node_modules/@types/node": {
             "version": "22.13.0",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/node/-/node-22.13.0.tgz",
             "integrity": "sha512-ClIbNe36lawluuvq3+YYhnIN2CELi+6q8NpnM7PYp4hBn/TatfboPgVSm2rwKRfnV2M+Ty9GWDFI64KEe+kysA==",
             "dev": true,
             "dependencies": {
@@ -2071,7 +2071,7 @@
         },
         "node_modules/@types/node-forge": {
             "version": "1.3.11",
-            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/node-forge/-/node-forge-1.3.11.tgz",
             "integrity": "sha512-FQx220y22OKNTqaByeBGqHWYz4cl94tpcxeFdvBo3wjG6XPBuZ0BNgNZRV5J5TFmmcsJ4IzsLkmGRiQbnYsBEQ==",
             "dev": true,
             "dependencies": {
@@ -2080,19 +2080,19 @@
         },
         "node_modules/@types/qs": {
             "version": "6.9.18",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/qs/-/qs-6.9.18.tgz",
             "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
             "dev": true
         },
         "node_modules/@types/range-parser": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/range-parser/-/range-parser-1.2.7.tgz",
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "dev": true
         },
         "node_modules/@types/react": {
             "version": "16.14.65",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.65.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/react/-/react-16.14.65.tgz",
             "integrity": "sha512-Guc3kE+W8LrQB9I3bF3blvNH15dXFIVIHIJTqrF8cp5XI/3IJcHGo4C3sJNPb8Zx49aofXKnAGIKyonE4f7XWg==",
             "license": "MIT",
             "dependencies": {
@@ -2101,7 +2101,7 @@
         },
         "node_modules/@types/react-dom": {
             "version": "16.9.25",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.25.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/react-dom/-/react-dom-16.9.25.tgz",
             "integrity": "sha512-ZK//eAPhwft9Ul2/Zj+6O11YR6L4JX0J2sVeBC9Ft7x7HFN7xk7yUV/zDxqV6rjvqgl6r8Dq7oQImxtyf/Mzcw==",
             "dev": true,
             "license": "MIT",
@@ -2111,13 +2111,13 @@
         },
         "node_modules/@types/retry": {
             "version": "0.12.2",
-            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/retry/-/retry-0.12.2.tgz",
             "integrity": "sha512-XISRgDJ2Tc5q4TRqvgJtzsRkFYNJzZrhTdtMoGVBttwzzQJkPnS3WWTFc7kuDRoPtPakl+T+OfdEUjYJj7Jbow==",
             "dev": true
         },
         "node_modules/@types/send": {
             "version": "0.17.4",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/send/-/send-0.17.4.tgz",
             "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
             "dev": true,
             "dependencies": {
@@ -2127,7 +2127,7 @@
         },
         "node_modules/@types/serve-index": {
             "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/serve-index/-/serve-index-1.9.4.tgz",
             "integrity": "sha512-qLpGZ/c2fhSs5gnYsQxtDEq3Oy8SXPClIXkW5ghvAvsNuVSA8k+gCONcUCS/UjLEYvYps+e8uBtfgXgvhwfNug==",
             "dev": true,
             "dependencies": {
@@ -2136,7 +2136,7 @@
         },
         "node_modules/@types/serve-static": {
             "version": "1.15.7",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/serve-static/-/serve-static-1.15.7.tgz",
             "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
             "dev": true,
             "dependencies": {
@@ -2147,7 +2147,7 @@
         },
         "node_modules/@types/sockjs": {
             "version": "0.3.36",
-            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.36.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/sockjs/-/sockjs-0.3.36.tgz",
             "integrity": "sha512-MK9V6NzAS1+Ud7JV9lJLFqW85VbC9dq3LmwZCuBe4wBDgKC0Kj/jd8Xl+nSviU+Qc3+m7umHHyHg//2KSa0a0Q==",
             "dev": true,
             "dependencies": {
@@ -2156,7 +2156,7 @@
         },
         "node_modules/@types/ws": {
             "version": "8.5.14",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.14.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/ws/-/ws-8.5.14.tgz",
             "integrity": "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw==",
             "dev": true,
             "dependencies": {
@@ -2165,7 +2165,7 @@
         },
         "node_modules/@webassemblyjs/ast": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/ast/-/ast-1.14.1.tgz",
             "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
             "dev": true,
             "dependencies": {
@@ -2175,25 +2175,25 @@
         },
         "node_modules/@webassemblyjs/floating-point-hex-parser": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
             "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-api-error": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
             "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-buffer": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
             "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-numbers": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
             "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
             "dev": true,
             "dependencies": {
@@ -2204,13 +2204,13 @@
         },
         "node_modules/@webassemblyjs/helper-wasm-bytecode": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
             "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
             "dev": true
         },
         "node_modules/@webassemblyjs/helper-wasm-section": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
             "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
             "dev": true,
             "dependencies": {
@@ -2222,7 +2222,7 @@
         },
         "node_modules/@webassemblyjs/ieee754": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
             "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
             "dev": true,
             "dependencies": {
@@ -2231,7 +2231,7 @@
         },
         "node_modules/@webassemblyjs/leb128": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
             "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
             "dev": true,
             "dependencies": {
@@ -2240,13 +2240,13 @@
         },
         "node_modules/@webassemblyjs/utf8": {
             "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
             "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
             "dev": true
         },
         "node_modules/@webassemblyjs/wasm-edit": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
             "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
             "dev": true,
             "dependencies": {
@@ -2262,7 +2262,7 @@
         },
         "node_modules/@webassemblyjs/wasm-gen": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
             "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
             "dev": true,
             "dependencies": {
@@ -2275,7 +2275,7 @@
         },
         "node_modules/@webassemblyjs/wasm-opt": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
             "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
             "dev": true,
             "dependencies": {
@@ -2287,7 +2287,7 @@
         },
         "node_modules/@webassemblyjs/wasm-parser": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
             "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
             "dev": true,
             "dependencies": {
@@ -2301,7 +2301,7 @@
         },
         "node_modules/@webassemblyjs/wast-printer": {
             "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
             "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
             "dev": true,
             "dependencies": {
@@ -2311,7 +2311,7 @@
         },
         "node_modules/@webpack-cli/configtest": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
             "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
             "dev": true,
             "engines": {
@@ -2324,7 +2324,7 @@
         },
         "node_modules/@webpack-cli/info": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webpack-cli/info/-/info-3.0.1.tgz",
             "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
             "dev": true,
             "engines": {
@@ -2337,7 +2337,7 @@
         },
         "node_modules/@webpack-cli/serve": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@webpack-cli/serve/-/serve-3.0.1.tgz",
             "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
             "dev": true,
             "engines": {
@@ -2355,19 +2355,19 @@
         },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
             "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
             "dev": true
         },
         "node_modules/@xtuc/long": {
             "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
         },
         "node_modules/accepts": {
             "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/accepts/-/accepts-1.3.8.tgz",
             "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
             "dev": true,
             "dependencies": {
@@ -2380,7 +2380,7 @@
         },
         "node_modules/accepts/node_modules/negotiator": {
             "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/negotiator/-/negotiator-0.6.3.tgz",
             "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
             "dev": true,
             "engines": {
@@ -2389,7 +2389,7 @@
         },
         "node_modules/acorn": {
             "version": "8.15.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
@@ -2402,7 +2402,7 @@
         },
         "node_modules/acorn-import-phases": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
             "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
             "dev": true,
             "license": "MIT",
@@ -2415,7 +2415,7 @@
         },
         "node_modules/ajv": {
             "version": "8.17.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "dev": true,
             "dependencies": {
@@ -2431,7 +2431,7 @@
         },
         "node_modules/ajv-formats": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
             "dev": true,
             "dependencies": {
@@ -2448,7 +2448,7 @@
         },
         "node_modules/ajv-keywords": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
             "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
             "dev": true,
             "dependencies": {
@@ -2460,14 +2460,14 @@
         },
         "node_modules/anser": {
             "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/anser/-/anser-2.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/anser/-/anser-2.3.2.tgz",
             "integrity": "sha512-PMqBCBvrOVDRqLGooQb+z+t1Q0PiPyurUQeZRR5uHBOVZcW8B04KMmnT12USnhpNX2wCPagWzLVppQMUG3u0Dw==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/ansi-html-community": {
             "version": "0.0.8",
-            "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
             "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
             "dev": true,
             "engines": [
@@ -2479,7 +2479,7 @@
         },
         "node_modules/ansi-regex": {
             "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-6.2.2.tgz",
             "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
             "dev": true,
             "license": "MIT",
@@ -2492,7 +2492,7 @@
         },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
             "dependencies": {
@@ -2507,7 +2507,7 @@
         },
         "node_modules/anymatch": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
             "dev": true,
             "dependencies": {
@@ -2520,7 +2520,7 @@
         },
         "node_modules/array-buffer-byte-length": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
             "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -2535,13 +2535,13 @@
         },
         "node_modules/array-flatten": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
             "dev": true
         },
         "node_modules/array.prototype.find": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
             "integrity": "sha512-bTk9+sjVFDEHXGn7UU9UlfD1FqdvE/oFNXCMxnsRQg+yS7rSltM9Wro9+EJQMYGljl6Bc4kOpBgLQaXbzTTCsw==",
             "dependencies": {
                 "define-properties": "^1.1.2",
@@ -2550,7 +2550,7 @@
         },
         "node_modules/arraybuffer.prototype.slice": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
             "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.1",
@@ -2570,7 +2570,7 @@
         },
         "node_modules/async-function": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/async-function/-/async-function-1.0.0.tgz",
             "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
             "engines": {
                 "node": ">= 0.4"
@@ -2578,7 +2578,7 @@
         },
         "node_modules/available-typed-arrays": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
             "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
             "dependencies": {
                 "possible-typed-array-names": "^1.0.0"
@@ -2592,7 +2592,7 @@
         },
         "node_modules/azure-devops-extension-api": {
             "version": "4.258.0",
-            "resolved": "https://registry.npmjs.org/azure-devops-extension-api/-/azure-devops-extension-api-4.258.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/azure-devops-extension-api/-/azure-devops-extension-api-4.258.0.tgz",
             "integrity": "sha512-aW15h06c8HNq2pjTQwgE610Y5EVpNwgFSNZM9ONsjd+8xaNR0yLRNy6+uQGn7wIiuAkMg6QnyclU+NGMxzwTNw==",
             "license": "MIT",
             "dependencies": {
@@ -2604,7 +2604,7 @@
         },
         "node_modules/azure-devops-extension-sdk": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/azure-devops-extension-sdk/-/azure-devops-extension-sdk-4.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/azure-devops-extension-sdk/-/azure-devops-extension-sdk-4.0.2.tgz",
             "integrity": "sha512-r8JwhjQT3el/X7XyMJGq/mlNDN/Cdpw5Dw/2nXcCdBmfyvDMgCcD0a+4EgL7Fi4ULcy+hPrlwejv8l1K4/XZSQ==",
             "engines": {
                 "node": ">=18.0.0"
@@ -2612,7 +2612,7 @@
         },
         "node_modules/azure-devops-ui": {
             "version": "2.259.0",
-            "resolved": "https://registry.npmjs.org/azure-devops-ui/-/azure-devops-ui-2.259.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/azure-devops-ui/-/azure-devops-ui-2.259.0.tgz",
             "integrity": "sha512-VLNplQPjKdQ51sXHC+c5NpYykSfpgZAG3lJUyMeeCfgQhMMQwOD4stgcE0KU04tQ/2cycxtysnv0pZPCjmuanA==",
             "license": "MIT",
             "dependencies": {
@@ -2630,12 +2630,12 @@
         },
         "node_modules/azure-devops-ui/node_modules/tslib": {
             "version": "2.6.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tslib/-/tslib-2.6.3.tgz",
             "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
         },
         "node_modules/babel-loader": {
             "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-10.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/babel-loader/-/babel-loader-10.0.0.tgz",
             "integrity": "sha512-z8jt+EdS61AMw22nSfoNJAZ0vrtmhPRVi6ghL3rCeRZI8cdNYFiV5xeV3HbE7rlZZNmGH8BVccwWt8/ED0QOHA==",
             "dev": true,
             "license": "MIT",
@@ -2652,7 +2652,7 @@
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
             "version": "0.4.14",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
             "integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
             "dev": true,
             "license": "MIT",
@@ -2667,7 +2667,7 @@
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
             "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.13.0.tgz",
             "integrity": "sha512-U+GNwMdSFgzVmfhNm8GJUX88AadB3uo9KpJqS3FaqNIPKgySuvMb+bHPsOmmuWyIcuqZj/pzt1RUIUZns4y2+A==",
             "dev": true,
             "license": "MIT",
@@ -2681,7 +2681,7 @@
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
             "version": "0.6.5",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
             "integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
             "dev": true,
             "license": "MIT",
@@ -2694,13 +2694,13 @@
         },
         "node_modules/batch": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/batch/-/batch-0.6.1.tgz",
             "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==",
             "dev": true
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/binary-extensions/-/binary-extensions-2.3.0.tgz",
             "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
             "dev": true,
             "engines": {
@@ -2712,7 +2712,7 @@
         },
         "node_modules/body-parser": {
             "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/body-parser/-/body-parser-1.20.4.tgz",
             "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
             "dev": true,
             "license": "MIT",
@@ -2737,7 +2737,7 @@
         },
         "node_modules/body-parser/node_modules/debug": {
             "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "dependencies": {
@@ -2746,7 +2746,7 @@
         },
         "node_modules/body-parser/node_modules/http-errors": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-errors/-/http-errors-2.0.1.tgz",
             "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "dev": true,
             "license": "MIT",
@@ -2767,13 +2767,13 @@
         },
         "node_modules/body-parser/node_modules/ms": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/body-parser/node_modules/statuses": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/statuses/-/statuses-2.0.2.tgz",
             "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
             "dev": true,
             "license": "MIT",
@@ -2783,7 +2783,7 @@
         },
         "node_modules/bonjour-service": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/bonjour-service/-/bonjour-service-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bonjour-service/-/bonjour-service-1.3.0.tgz",
             "integrity": "sha512-3YuAUiSkWykd+2Azjgyxei8OWf8thdn8AITIog2M4UICzoqfjlqr64WIjEXZllf/W6vK1goqleSR6brGomxQqA==",
             "dev": true,
             "dependencies": {
@@ -2793,7 +2793,7 @@
         },
         "node_modules/braces": {
             "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/braces/-/braces-3.0.3.tgz",
             "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "dependencies": {
@@ -2805,7 +2805,7 @@
         },
         "node_modules/browserslist": {
             "version": "4.25.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/browserslist/-/browserslist-4.25.1.tgz",
             "integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
             "dev": true,
             "funding": [
@@ -2838,13 +2838,13 @@
         },
         "node_modules/buffer-from": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/buffer-from/-/buffer-from-1.1.2.tgz",
             "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
             "dev": true
         },
         "node_modules/bundle-name": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bundle-name/-/bundle-name-4.1.0.tgz",
             "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
             "dev": true,
             "dependencies": {
@@ -2859,7 +2859,7 @@
         },
         "node_modules/bytes": {
             "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
             "dev": true,
             "engines": {
@@ -2868,7 +2868,7 @@
         },
         "node_modules/call-bind": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind/-/call-bind-1.0.8.tgz",
             "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.0",
@@ -2885,7 +2885,7 @@
         },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
             "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -2897,7 +2897,7 @@
         },
         "node_modules/call-bound": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/call-bound/-/call-bound-1.0.3.tgz",
             "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -2912,7 +2912,7 @@
         },
         "node_modules/caniuse-lite": {
             "version": "1.0.30001731",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/caniuse-lite/-/caniuse-lite-1.0.30001731.tgz",
             "integrity": "sha512-lDdp2/wrOmTRWuoB5DpfNkC0rJDU8DqRa6nYL6HK6sytw70QMopt/NIc/9SM7ylItlBWfACXk0tEn37UWM/+mg==",
             "dev": true,
             "funding": [
@@ -2933,7 +2933,7 @@
         },
         "node_modules/chalk": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
             "dependencies": {
@@ -2949,7 +2949,7 @@
         },
         "node_modules/chokidar": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chokidar/-/chokidar-3.6.0.tgz",
             "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
             "dependencies": {
@@ -2973,7 +2973,7 @@
         },
         "node_modules/chokidar/node_modules/glob-parent": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
             "dependencies": {
@@ -2985,7 +2985,7 @@
         },
         "node_modules/chrome-trace-event": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
             "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
             "dev": true,
             "engines": {
@@ -2994,7 +2994,7 @@
         },
         "node_modules/clone-deep": {
             "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/clone-deep/-/clone-deep-4.0.1.tgz",
             "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
             "dev": true,
             "dependencies": {
@@ -3008,7 +3008,7 @@
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
             "dependencies": {
@@ -3020,25 +3020,25 @@
         },
         "node_modules/color-name": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
         },
         "node_modules/colorette": {
             "version": "2.0.20",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/colorette/-/colorette-2.0.20.tgz",
             "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
             "dev": true
         },
         "node_modules/commander": {
             "version": "2.20.3",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/commander/-/commander-2.20.3.tgz",
             "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
             "dev": true
         },
         "node_modules/compressible": {
             "version": "2.0.18",
-            "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/compressible/-/compressible-2.0.18.tgz",
             "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
             "dev": true,
             "dependencies": {
@@ -3050,7 +3050,7 @@
         },
         "node_modules/compression": {
             "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/compression/-/compression-1.8.1.tgz",
             "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
             "dev": true,
             "license": "MIT",
@@ -3069,7 +3069,7 @@
         },
         "node_modules/compression/node_modules/debug": {
             "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "dependencies": {
@@ -3078,13 +3078,13 @@
         },
         "node_modules/compression/node_modules/ms": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/connect-history-api-fallback": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/connect-history-api-fallback/-/connect-history-api-fallback-2.0.0.tgz",
             "integrity": "sha512-U73+6lQFmfiNPrYbXqr6kZ1i1wiRqXnp2nhMsINseWXO8lDau0LGEffJ8kQi4EjLZympVgRdvqjAgiZ1tgzDDA==",
             "dev": true,
             "engines": {
@@ -3093,7 +3093,7 @@
         },
         "node_modules/content-disposition": {
             "version": "0.5.4",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/content-disposition/-/content-disposition-0.5.4.tgz",
             "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
             "dev": true,
             "dependencies": {
@@ -3105,7 +3105,7 @@
         },
         "node_modules/content-type": {
             "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/content-type/-/content-type-1.0.5.tgz",
             "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
             "dev": true,
             "engines": {
@@ -3114,13 +3114,13 @@
         },
         "node_modules/convert-source-map": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/convert-source-map/-/convert-source-map-2.0.0.tgz",
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true
         },
         "node_modules/cookie": {
             "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cookie/-/cookie-0.7.1.tgz",
             "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
             "dev": true,
             "engines": {
@@ -3129,13 +3129,13 @@
         },
         "node_modules/cookie-signature": {
             "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cookie-signature/-/cookie-signature-1.0.6.tgz",
             "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
             "dev": true
         },
         "node_modules/copy-webpack-plugin": {
             "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/copy-webpack-plugin/-/copy-webpack-plugin-13.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/copy-webpack-plugin/-/copy-webpack-plugin-13.0.0.tgz",
             "integrity": "sha512-FgR/h5a6hzJqATDGd9YG41SeDViH+0bkHn6WNXCi5zKAZkeESeSxLySSsFLHqLEVCh0E+rITmCf0dusXWYukeQ==",
             "dev": true,
             "license": "MIT",
@@ -3159,7 +3159,7 @@
         },
         "node_modules/core-js-compat": {
             "version": "3.45.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/core-js-compat/-/core-js-compat-3.45.0.tgz",
             "integrity": "sha512-gRoVMBawZg0OnxaVv3zpqLLxaHmsubEGyTnqdpI/CEBvX4JadI1dMSHxagThprYRtSVbuQxvi6iUatdPxohHpA==",
             "dev": true,
             "license": "MIT",
@@ -3173,7 +3173,7 @@
         },
         "node_modules/core-js-pure": {
             "version": "3.40.0",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.40.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/core-js-pure/-/core-js-pure-3.40.0.tgz",
             "integrity": "sha512-AtDzVIgRrmRKQai62yuSIN5vNiQjcJakJb4fbhVw3ehxx7Lohphvw9SGNWKhLFqSxC4ilD0g/L1huAYFQU3Q6A==",
             "dev": true,
             "hasInstallScript": true,
@@ -3184,13 +3184,13 @@
         },
         "node_modules/core-util-is": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/core-util-is/-/core-util-is-1.0.3.tgz",
             "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
             "dev": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
             "dependencies": {
@@ -3204,7 +3204,7 @@
         },
         "node_modules/css-loader": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/css-loader/-/css-loader-7.1.2.tgz",
             "integrity": "sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==",
             "dev": true,
             "dependencies": {
@@ -3239,7 +3239,7 @@
         },
         "node_modules/css-loader/node_modules/semver": {
             "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-7.7.0.tgz",
             "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
             "dev": true,
             "bin": {
@@ -3251,7 +3251,7 @@
         },
         "node_modules/cssesc": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/cssesc/-/cssesc-3.0.0.tgz",
             "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true,
             "bin": {
@@ -3263,12 +3263,12 @@
         },
         "node_modules/csstype": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/csstype/-/csstype-3.1.3.tgz",
             "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
             "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -3284,7 +3284,7 @@
         },
         "node_modules/data-view-byte-length": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
             "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -3300,7 +3300,7 @@
         },
         "node_modules/data-view-byte-offset": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
             "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -3316,7 +3316,7 @@
         },
         "node_modules/debug": {
             "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-4.4.1.tgz",
             "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
             "dev": true,
             "license": "MIT",
@@ -3334,7 +3334,7 @@
         },
         "node_modules/default-browser": {
             "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/default-browser/-/default-browser-5.2.1.tgz",
             "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
             "dev": true,
             "dependencies": {
@@ -3350,7 +3350,7 @@
         },
         "node_modules/default-browser-id": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/default-browser-id/-/default-browser-id-5.0.0.tgz",
             "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
             "dev": true,
             "engines": {
@@ -3362,7 +3362,7 @@
         },
         "node_modules/define-data-property": {
             "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/define-data-property/-/define-data-property-1.1.4.tgz",
             "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
             "dependencies": {
                 "es-define-property": "^1.0.0",
@@ -3378,7 +3378,7 @@
         },
         "node_modules/define-lazy-prop": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
             "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
             "dev": true,
             "engines": {
@@ -3390,7 +3390,7 @@
         },
         "node_modules/define-properties": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/define-properties/-/define-properties-1.2.1.tgz",
             "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
             "dependencies": {
                 "define-data-property": "^1.0.1",
@@ -3406,7 +3406,7 @@
         },
         "node_modules/depd": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/depd/-/depd-2.0.0.tgz",
             "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
             "dev": true,
             "engines": {
@@ -3415,7 +3415,7 @@
         },
         "node_modules/destroy": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/destroy/-/destroy-1.2.0.tgz",
             "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
             "dev": true,
             "engines": {
@@ -3425,13 +3425,13 @@
         },
         "node_modules/detect-node": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/detect-node/-/detect-node-2.1.0.tgz",
             "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
             "dev": true
         },
         "node_modules/dns-packet": {
             "version": "5.6.1",
-            "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/dns-packet/-/dns-packet-5.6.1.tgz",
             "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
             "dev": true,
             "dependencies": {
@@ -3443,7 +3443,7 @@
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/dunder-proto/-/dunder-proto-1.0.1.tgz",
             "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -3456,34 +3456,34 @@
         },
         "node_modules/eastasianwidth": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ee-first/-/ee-first-1.1.1.tgz",
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
             "dev": true
         },
         "node_modules/electron-to-chromium": {
             "version": "1.5.198",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.198.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/electron-to-chromium/-/electron-to-chromium-1.5.198.tgz",
             "integrity": "sha512-G5COfnp3w+ydVu80yprgWSfmfQaYRh9DOxfhAxstLyetKaLyl55QrNjx8C38Pc/C+RaDmb1M0Lk8wPEMQ+bGgQ==",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-9.2.2.tgz",
             "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/encodeurl": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/encodeurl/-/encodeurl-2.0.0.tgz",
             "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
             "dev": true,
             "engines": {
@@ -3492,7 +3492,7 @@
         },
         "node_modules/enhanced-resolve": {
             "version": "5.18.0",
-            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/enhanced-resolve/-/enhanced-resolve-5.18.0.tgz",
             "integrity": "sha512-0/r0MySGYG8YqlayBZ6MuCfECmHFdJ5qyPh8s8wa5Hnm6SaFLSK1VYCbj+NKp090Nm1caZhD+QTnmxO7esYGyQ==",
             "dev": true,
             "dependencies": {
@@ -3505,7 +3505,7 @@
         },
         "node_modules/envinfo": {
             "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/envinfo/-/envinfo-7.14.0.tgz",
             "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
             "dev": true,
             "bin": {
@@ -3517,7 +3517,7 @@
         },
         "node_modules/error-stack-parser": {
             "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
             "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
             "dev": true,
             "dependencies": {
@@ -3526,7 +3526,7 @@
         },
         "node_modules/es-abstract": {
             "version": "1.23.9",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-abstract/-/es-abstract-1.23.9.tgz",
             "integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
             "dependencies": {
                 "array-buffer-byte-length": "^1.0.2",
@@ -3590,7 +3590,7 @@
         },
         "node_modules/es-define-property": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-define-property/-/es-define-property-1.0.1.tgz",
             "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
             "engines": {
                 "node": ">= 0.4"
@@ -3598,7 +3598,7 @@
         },
         "node_modules/es-errors": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-errors/-/es-errors-1.3.0.tgz",
             "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
             "engines": {
                 "node": ">= 0.4"
@@ -3606,13 +3606,13 @@
         },
         "node_modules/es-module-lexer": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
             "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
             "dev": true
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
             "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
             "dependencies": {
                 "es-errors": "^1.3.0"
@@ -3623,7 +3623,7 @@
         },
         "node_modules/es-set-tostringtag": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -3637,7 +3637,7 @@
         },
         "node_modules/es-to-primitive": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es-to-primitive/-/es-to-primitive-1.3.0.tgz",
             "integrity": "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==",
             "dependencies": {
                 "is-callable": "^1.2.7",
@@ -3653,17 +3653,17 @@
         },
         "node_modules/es6-object-assign": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
             "integrity": "sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw=="
         },
         "node_modules/es6-promise": {
             "version": "4.2.8",
-            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es6-promise/-/es6-promise-4.2.8.tgz",
             "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "node_modules/es6-string-polyfills": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/es6-string-polyfills/-/es6-string-polyfills-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/es6-string-polyfills/-/es6-string-polyfills-1.0.0.tgz",
             "integrity": "sha512-KE0HeoFY2w0uXJoIJGrlCNE+u2TBcPnboZRJ6uIUokG8C0wOm67KIUVEupLJsAwmrQvUZoMAMYdPMNMutAgQMQ==",
             "dependencies": {
                 "string.fromcodepoint": "^0.2.1",
@@ -3676,7 +3676,7 @@
         },
         "node_modules/escalade": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/escalade/-/escalade-3.2.0.tgz",
             "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
             "dev": true,
             "license": "MIT",
@@ -3686,13 +3686,13 @@
         },
         "node_modules/escape-html": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/escape-html/-/escape-html-1.0.3.tgz",
             "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
             "dev": true
         },
         "node_modules/eslint-scope": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
             "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
             "dev": true,
             "dependencies": {
@@ -3705,7 +3705,7 @@
         },
         "node_modules/esrecurse": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
             "dependencies": {
@@ -3717,7 +3717,7 @@
         },
         "node_modules/esrecurse/node_modules/estraverse": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
             "engines": {
@@ -3726,7 +3726,7 @@
         },
         "node_modules/estraverse": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/estraverse/-/estraverse-4.3.0.tgz",
             "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
             "dev": true,
             "engines": {
@@ -3735,7 +3735,7 @@
         },
         "node_modules/esutils": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
             "engines": {
@@ -3744,7 +3744,7 @@
         },
         "node_modules/etag": {
             "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/etag/-/etag-1.8.1.tgz",
             "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
             "dev": true,
             "engines": {
@@ -3753,13 +3753,13 @@
         },
         "node_modules/eventemitter3": {
             "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "dev": true
         },
         "node_modules/events": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/events/-/events-3.3.0.tgz",
             "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
             "dev": true,
             "engines": {
@@ -3768,7 +3768,7 @@
         },
         "node_modules/express": {
             "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/express/-/express-4.22.1.tgz",
             "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
             "dev": true,
             "license": "MIT",
@@ -3815,7 +3815,7 @@
         },
         "node_modules/express/node_modules/debug": {
             "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "dependencies": {
@@ -3824,19 +3824,19 @@
         },
         "node_modules/express/node_modules/ms": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
             "dev": true
         },
         "node_modules/fast-uri": {
             "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fast-uri/-/fast-uri-3.0.6.tgz",
             "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
             "dev": true,
             "funding": [
@@ -3852,7 +3852,7 @@
         },
         "node_modules/fastest-levenshtein": {
             "version": "1.0.16",
-            "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
             "integrity": "sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==",
             "dev": true,
             "engines": {
@@ -3861,7 +3861,7 @@
         },
         "node_modules/faye-websocket": {
             "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/faye-websocket/-/faye-websocket-0.11.4.tgz",
             "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
             "dev": true,
             "dependencies": {
@@ -3873,7 +3873,7 @@
         },
         "node_modules/fill-range": {
             "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fill-range/-/fill-range-7.1.1.tgz",
             "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "dependencies": {
@@ -3885,7 +3885,7 @@
         },
         "node_modules/finalhandler": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/finalhandler/-/finalhandler-1.3.1.tgz",
             "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
             "dev": true,
             "dependencies": {
@@ -3903,7 +3903,7 @@
         },
         "node_modules/finalhandler/node_modules/debug": {
             "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "dependencies": {
@@ -3912,13 +3912,13 @@
         },
         "node_modules/finalhandler/node_modules/ms": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/find-up": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
             "license": "MIT",
@@ -3935,7 +3935,7 @@
         },
         "node_modules/flat": {
             "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/flat/-/flat-5.0.2.tgz",
             "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
             "dev": true,
             "bin": {
@@ -3944,7 +3944,7 @@
         },
         "node_modules/follow-redirects": {
             "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/follow-redirects/-/follow-redirects-1.15.9.tgz",
             "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
             "dev": true,
             "funding": [
@@ -3964,7 +3964,7 @@
         },
         "node_modules/for-each": {
             "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/for-each/-/for-each-0.3.4.tgz",
             "integrity": "sha512-kKaIINnFpzW6ffJNDjjyjrk21BkDx38c0xa/klsT8VzLCaMEefv4ZTacrcVR4DmgTeBra++jMDAfS/tS799YDw==",
             "dependencies": {
                 "is-callable": "^1.2.7"
@@ -3978,7 +3978,7 @@
         },
         "node_modules/foreground-child": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/foreground-child/-/foreground-child-3.3.1.tgz",
             "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
             "dev": true,
             "dependencies": {
@@ -3994,7 +3994,7 @@
         },
         "node_modules/forwarded": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/forwarded/-/forwarded-0.2.0.tgz",
             "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
             "dev": true,
             "engines": {
@@ -4003,7 +4003,7 @@
         },
         "node_modules/fresh": {
             "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fresh/-/fresh-0.5.2.tgz",
             "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
             "dev": true,
             "engines": {
@@ -4012,7 +4012,7 @@
         },
         "node_modules/fsevents": {
             "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
             "dev": true,
             "hasInstallScript": true,
@@ -4026,7 +4026,7 @@
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/function-bind/-/function-bind-1.1.2.tgz",
             "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4034,7 +4034,7 @@
         },
         "node_modules/function.prototype.name": {
             "version": "1.1.8",
-            "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/function.prototype.name/-/function.prototype.name-1.1.8.tgz",
             "integrity": "sha512-e5iwyodOHhbMr/yNrc7fDYG4qlbIvI5gajyzPnb5TCwyhjApznQh1BMFou9b30SevY43gCJKXycoCBjMbsuW0Q==",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -4053,7 +4053,7 @@
         },
         "node_modules/functions-have-names": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/functions-have-names/-/functions-have-names-1.2.3.tgz",
             "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -4061,7 +4061,7 @@
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/gensync/-/gensync-1.0.0-beta.2.tgz",
             "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
             "dev": true,
             "engines": {
@@ -4070,7 +4070,7 @@
         },
         "node_modules/get-intrinsic": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
             "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
             "dependencies": {
                 "call-bind-apply-helpers": "^1.0.1",
@@ -4093,7 +4093,7 @@
         },
         "node_modules/get-proto": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-proto/-/get-proto-1.0.1.tgz",
             "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -4105,7 +4105,7 @@
         },
         "node_modules/get-symbol-description": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
             "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -4121,7 +4121,7 @@
         },
         "node_modules/glob": {
             "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob/-/glob-11.1.0.tgz",
             "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -4145,7 +4145,7 @@
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
             "dependencies": {
@@ -4157,13 +4157,13 @@
         },
         "node_modules/glob-to-regexp": {
             "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
             "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
             "dev": true
         },
         "node_modules/globalthis": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/globalthis/-/globalthis-1.0.4.tgz",
             "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
             "dependencies": {
                 "define-properties": "^1.2.1",
@@ -4178,7 +4178,7 @@
         },
         "node_modules/gopd": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/gopd/-/gopd-1.2.0.tgz",
             "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
             "engines": {
                 "node": ">= 0.4"
@@ -4189,19 +4189,19 @@
         },
         "node_modules/graceful-fs": {
             "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/graceful-fs/-/graceful-fs-4.2.11.tgz",
             "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
             "dev": true
         },
         "node_modules/handle-thing": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/handle-thing/-/handle-thing-2.0.1.tgz",
             "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
             "dev": true
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-bigints/-/has-bigints-1.1.0.tgz",
             "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
             "engines": {
                 "node": ">= 0.4"
@@ -4212,7 +4212,7 @@
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
             "engines": {
@@ -4221,7 +4221,7 @@
         },
         "node_modules/has-property-descriptors": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
             "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
             "dependencies": {
                 "es-define-property": "^1.0.0"
@@ -4232,7 +4232,7 @@
         },
         "node_modules/has-proto": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-proto/-/has-proto-1.2.0.tgz",
             "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
             "dependencies": {
                 "dunder-proto": "^1.0.0"
@@ -4246,7 +4246,7 @@
         },
         "node_modules/has-symbols": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-symbols/-/has-symbols-1.1.0.tgz",
             "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
             "engines": {
                 "node": ">= 0.4"
@@ -4257,7 +4257,7 @@
         },
         "node_modules/has-tostringtag": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
             "dependencies": {
                 "has-symbols": "^1.0.3"
@@ -4271,7 +4271,7 @@
         },
         "node_modules/hasown": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/hasown/-/hasown-2.0.2.tgz",
             "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
             "dependencies": {
                 "function-bind": "^1.1.2"
@@ -4282,7 +4282,7 @@
         },
         "node_modules/hpack.js": {
             "version": "2.1.6",
-            "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/hpack.js/-/hpack.js-2.1.6.tgz",
             "integrity": "sha512-zJxVehUdMGIKsRaNt7apO2Gqp0BdqW5yaiGHXXmbpvxgBYVZnAql+BJb4RO5ad2MgpbZKn5G6nMnegrH1FcNYQ==",
             "dev": true,
             "dependencies": {
@@ -4294,7 +4294,7 @@
         },
         "node_modules/hpack.js/node_modules/readable-stream": {
             "version": "2.3.8",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/readable-stream/-/readable-stream-2.3.8.tgz",
             "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
             "dev": true,
             "dependencies": {
@@ -4309,13 +4309,13 @@
         },
         "node_modules/hpack.js/node_modules/safe-buffer": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
         "node_modules/hpack.js/node_modules/string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "dependencies": {
@@ -4324,7 +4324,7 @@
         },
         "node_modules/html-entities": {
             "version": "2.5.2",
-            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/html-entities/-/html-entities-2.5.2.tgz",
             "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
             "dev": true,
             "funding": [
@@ -4340,13 +4340,13 @@
         },
         "node_modules/http-deceiver": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/http-deceiver/-/http-deceiver-1.2.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-deceiver/-/http-deceiver-1.2.7.tgz",
             "integrity": "sha512-LmpOGxTfbpgtGVxJrj5k7asXHCgNZp5nLfp+hWc8QQRqtb7fUy6kRY3BO1h9ddF6yIPYUARgxGOwB42DnxIaNw==",
             "dev": true
         },
         "node_modules/http-errors": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-errors/-/http-errors-2.0.0.tgz",
             "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
             "dev": true,
             "dependencies": {
@@ -4362,13 +4362,13 @@
         },
         "node_modules/http-parser-js": {
             "version": "0.5.9",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-parser-js/-/http-parser-js-0.5.9.tgz",
             "integrity": "sha512-n1XsPy3rXVxlqxVioEWdC+0+M+SQw0DpJynwtOPo1X+ZlvdzTLtDBIJJlDQTnwZIFJrZSzSGmIOUdP8tu+SgLw==",
             "dev": true
         },
         "node_modules/http-proxy": {
             "version": "1.18.1",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-proxy/-/http-proxy-1.18.1.tgz",
             "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
             "dev": true,
             "dependencies": {
@@ -4382,7 +4382,7 @@
         },
         "node_modules/http-proxy-middleware": {
             "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
             "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
             "dev": true,
             "license": "MIT",
@@ -4407,7 +4407,7 @@
         },
         "node_modules/hyperdyperid": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
             "integrity": "sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==",
             "dev": true,
             "engines": {
@@ -4416,7 +4416,7 @@
         },
         "node_modules/iconv-lite": {
             "version": "0.4.24",
-            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/iconv-lite/-/iconv-lite-0.4.24.tgz",
             "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
             "dev": true,
             "license": "MIT",
@@ -4429,7 +4429,7 @@
         },
         "node_modules/icss-utils": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/icss-utils/-/icss-utils-5.1.0.tgz",
             "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
             "dev": true,
             "engines": {
@@ -4441,7 +4441,7 @@
         },
         "node_modules/import-local": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/import-local/-/import-local-3.2.0.tgz",
             "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
             "dev": true,
             "dependencies": {
@@ -4460,7 +4460,7 @@
         },
         "node_modules/import-local/node_modules/find-up": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/find-up/-/find-up-4.1.0.tgz",
             "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
             "dev": true,
             "dependencies": {
@@ -4473,7 +4473,7 @@
         },
         "node_modules/import-local/node_modules/locate-path": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/locate-path/-/locate-path-5.0.0.tgz",
             "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
             "dev": true,
             "dependencies": {
@@ -4485,7 +4485,7 @@
         },
         "node_modules/import-local/node_modules/p-limit": {
             "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
             "dev": true,
             "dependencies": {
@@ -4500,7 +4500,7 @@
         },
         "node_modules/import-local/node_modules/p-locate": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-locate/-/p-locate-4.1.0.tgz",
             "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
             "dev": true,
             "dependencies": {
@@ -4512,7 +4512,7 @@
         },
         "node_modules/import-local/node_modules/pkg-dir": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/pkg-dir/-/pkg-dir-4.2.0.tgz",
             "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
             "dev": true,
             "dependencies": {
@@ -4524,13 +4524,13 @@
         },
         "node_modules/inherits": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/internal-slot/-/internal-slot-1.1.0.tgz",
             "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -4543,7 +4543,7 @@
         },
         "node_modules/interpret": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/interpret/-/interpret-3.1.1.tgz",
             "integrity": "sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==",
             "dev": true,
             "engines": {
@@ -4552,12 +4552,12 @@
         },
         "node_modules/intersection-observer": {
             "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/intersection-observer/-/intersection-observer-0.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/intersection-observer/-/intersection-observer-0.5.1.tgz",
             "integrity": "sha512-Zd7Plneq82kiXFixs7bX62YnuZ0BMRci9br7io88LwDyF3V43cQMI+G5IiTlTNTt+LsDUppl19J/M2Fp9UkH6g=="
         },
         "node_modules/ipaddr.js": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
             "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
             "dev": true,
             "engines": {
@@ -4566,7 +4566,7 @@
         },
         "node_modules/is-array-buffer": {
             "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
             "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -4582,7 +4582,7 @@
         },
         "node_modules/is-async-function": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-async-function/-/is-async-function-2.1.1.tgz",
             "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
             "dependencies": {
                 "async-function": "^1.0.0",
@@ -4600,7 +4600,7 @@
         },
         "node_modules/is-bigint": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-bigint/-/is-bigint-1.1.0.tgz",
             "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
             "dependencies": {
                 "has-bigints": "^1.0.2"
@@ -4614,7 +4614,7 @@
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-binary-path/-/is-binary-path-2.1.0.tgz",
             "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
             "dev": true,
             "dependencies": {
@@ -4626,7 +4626,7 @@
         },
         "node_modules/is-boolean-object": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-boolean-object/-/is-boolean-object-1.2.1.tgz",
             "integrity": "sha512-l9qO6eFlUETHtuihLcYOaLKByJ1f+N4kthcU9YjHy3N+B3hWv0y/2Nd0mu/7lTFnRQHTrSdXF50HQ3bl5fEnng==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -4641,7 +4641,7 @@
         },
         "node_modules/is-callable": {
             "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-callable/-/is-callable-1.2.7.tgz",
             "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
             "engines": {
                 "node": ">= 0.4"
@@ -4652,7 +4652,7 @@
         },
         "node_modules/is-core-module": {
             "version": "2.16.1",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-core-module/-/is-core-module-2.16.1.tgz",
             "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
             "dev": true,
             "dependencies": {
@@ -4667,7 +4667,7 @@
         },
         "node_modules/is-data-view": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-data-view/-/is-data-view-1.0.2.tgz",
             "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -4683,7 +4683,7 @@
         },
         "node_modules/is-date-object": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-date-object/-/is-date-object-1.1.0.tgz",
             "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -4698,7 +4698,7 @@
         },
         "node_modules/is-docker": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-docker/-/is-docker-3.0.0.tgz",
             "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
             "dev": true,
             "bin": {
@@ -4713,7 +4713,7 @@
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
             "engines": {
@@ -4722,7 +4722,7 @@
         },
         "node_modules/is-finalizationregistry": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
             "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
             "dependencies": {
                 "call-bound": "^1.0.3"
@@ -4736,7 +4736,7 @@
         },
         "node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
             "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
             "dev": true,
             "license": "MIT",
@@ -4746,7 +4746,7 @@
         },
         "node_modules/is-generator-function": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-generator-function/-/is-generator-function-1.1.0.tgz",
             "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -4763,7 +4763,7 @@
         },
         "node_modules/is-glob": {
             "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
             "dependencies": {
@@ -4775,7 +4775,7 @@
         },
         "node_modules/is-inside-container": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-inside-container/-/is-inside-container-1.0.0.tgz",
             "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
             "dev": true,
             "dependencies": {
@@ -4793,7 +4793,7 @@
         },
         "node_modules/is-map": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-map/-/is-map-2.0.3.tgz",
             "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
             "engines": {
                 "node": ">= 0.4"
@@ -4804,7 +4804,7 @@
         },
         "node_modules/is-network-error": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-network-error/-/is-network-error-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-network-error/-/is-network-error-1.1.0.tgz",
             "integrity": "sha512-tUdRRAnhT+OtCZR/LxZelH/C7QtjtFrTu5tXCA8pl55eTUElUHT+GPYV8MBMBvea/j+NxQqVt3LbWMRir7Gx9g==",
             "dev": true,
             "engines": {
@@ -4816,7 +4816,7 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
             "engines": {
@@ -4825,7 +4825,7 @@
         },
         "node_modules/is-number-object": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-number-object/-/is-number-object-1.1.1.tgz",
             "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -4840,7 +4840,7 @@
         },
         "node_modules/is-plain-obj": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
             "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
             "dev": true,
             "engines": {
@@ -4852,7 +4852,7 @@
         },
         "node_modules/is-plain-object": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "dependencies": {
@@ -4864,7 +4864,7 @@
         },
         "node_modules/is-regex": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-regex/-/is-regex-1.2.1.tgz",
             "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -4881,7 +4881,7 @@
         },
         "node_modules/is-set": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-set/-/is-set-2.0.3.tgz",
             "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
             "engines": {
                 "node": ">= 0.4"
@@ -4892,7 +4892,7 @@
         },
         "node_modules/is-shared-array-buffer": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
             "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
             "dependencies": {
                 "call-bound": "^1.0.3"
@@ -4906,7 +4906,7 @@
         },
         "node_modules/is-string": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-string/-/is-string-1.1.1.tgz",
             "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -4921,7 +4921,7 @@
         },
         "node_modules/is-symbol": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-symbol/-/is-symbol-1.1.1.tgz",
             "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -4937,7 +4937,7 @@
         },
         "node_modules/is-typed-array": {
             "version": "1.1.15",
-            "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-typed-array/-/is-typed-array-1.1.15.tgz",
             "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
             "dependencies": {
                 "which-typed-array": "^1.1.16"
@@ -4951,7 +4951,7 @@
         },
         "node_modules/is-weakmap": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakmap/-/is-weakmap-2.0.2.tgz",
             "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
             "engines": {
                 "node": ">= 0.4"
@@ -4962,7 +4962,7 @@
         },
         "node_modules/is-weakref": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakref/-/is-weakref-1.1.0.tgz",
             "integrity": "sha512-SXM8Nwyys6nT5WP6pltOwKytLV7FqQ4UiibxVmW+EIosHcmCqkkjViTb5SNssDlkCiEYRP1/pdWUKVvZBmsR2Q==",
             "dependencies": {
                 "call-bound": "^1.0.2"
@@ -4976,7 +4976,7 @@
         },
         "node_modules/is-weakset": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-weakset/-/is-weakset-2.0.4.tgz",
             "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -4991,7 +4991,7 @@
         },
         "node_modules/is-wsl": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/is-wsl/-/is-wsl-3.1.0.tgz",
             "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
             "dev": true,
             "dependencies": {
@@ -5006,19 +5006,19 @@
         },
         "node_modules/isarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-1.0.0.tgz",
             "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
             "dev": true
         },
         "node_modules/isexe": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "dev": true
         },
         "node_modules/isobject": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isobject/-/isobject-3.0.1.tgz",
             "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
             "dev": true,
             "engines": {
@@ -5027,7 +5027,7 @@
         },
         "node_modules/jackspeak": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jackspeak/-/jackspeak-4.1.1.tgz",
             "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -5043,7 +5043,7 @@
         },
         "node_modules/jest-worker": {
             "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jest-worker/-/jest-worker-27.5.1.tgz",
             "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
             "dev": true,
             "dependencies": {
@@ -5057,7 +5057,7 @@
         },
         "node_modules/jest-worker/node_modules/supports-color": {
             "version": "8.1.1",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-color/-/supports-color-8.1.1.tgz",
             "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
             "dev": true,
             "dependencies": {
@@ -5072,12 +5072,12 @@
         },
         "node_modules/js-tokens": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jsesc/-/jsesc-3.1.0.tgz",
             "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
             "dev": true,
             "license": "MIT",
@@ -5090,19 +5090,19 @@
         },
         "node_modules/json-parse-even-better-errors": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
             "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
             "dev": true
         },
         "node_modules/json-schema-traverse": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
         "node_modules/json5": {
             "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/json5/-/json5-2.2.3.tgz",
             "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
             "dev": true,
             "bin": {
@@ -5114,7 +5114,7 @@
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
             "dev": true,
             "engines": {
@@ -5123,7 +5123,7 @@
         },
         "node_modules/launch-editor": {
             "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.9.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/launch-editor/-/launch-editor-2.9.1.tgz",
             "integrity": "sha512-Gcnl4Bd+hRO9P9icCP/RVVT2o8SFlPXofuCxvA2SaZuH45whSvf5p8x5oih5ftLiVhEI4sp5xDY+R+b3zJBh5w==",
             "dev": true,
             "dependencies": {
@@ -5133,7 +5133,7 @@
         },
         "node_modules/loader-runner": {
             "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/loader-runner/-/loader-runner-4.3.0.tgz",
             "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
             "dev": true,
             "engines": {
@@ -5142,7 +5142,7 @@
         },
         "node_modules/locate-path": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
             "license": "MIT",
@@ -5158,14 +5158,14 @@
         },
         "node_modules/lodash.debounce": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/loose-envify": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -5176,7 +5176,7 @@
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-5.1.1.tgz",
             "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
             "dev": true,
             "dependencies": {
@@ -5185,7 +5185,7 @@
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
             "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
             "engines": {
                 "node": ">= 0.4"
@@ -5193,7 +5193,7 @@
         },
         "node_modules/media-typer": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
             "dev": true,
             "engines": {
@@ -5202,7 +5202,7 @@
         },
         "node_modules/memfs": {
             "version": "4.17.0",
-            "resolved": "https://registry.npmjs.org/memfs/-/memfs-4.17.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/memfs/-/memfs-4.17.0.tgz",
             "integrity": "sha512-4eirfZ7thblFmqFjywlTmuWVSvccHAJbn1r8qQLzmTO11qcqpohOjmY2mFce6x7x7WtskzRqApPD0hv+Oa74jg==",
             "dev": true,
             "dependencies": {
@@ -5221,7 +5221,7 @@
         },
         "node_modules/merge-descriptors": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
             "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
             "dev": true,
             "funding": {
@@ -5230,13 +5230,13 @@
         },
         "node_modules/merge-stream": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
             "dev": true
         },
         "node_modules/methods": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/methods/-/methods-1.1.2.tgz",
             "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
             "dev": true,
             "engines": {
@@ -5245,7 +5245,7 @@
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/micromatch/-/micromatch-4.0.8.tgz",
             "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
             "dependencies": {
@@ -5258,7 +5258,7 @@
         },
         "node_modules/mime": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mime/-/mime-1.6.0.tgz",
             "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true,
             "bin": {
@@ -5270,7 +5270,7 @@
         },
         "node_modules/mime-db": {
             "version": "1.52.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
             "dev": true,
             "engines": {
@@ -5279,7 +5279,7 @@
         },
         "node_modules/mime-types": {
             "version": "2.1.35",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
             "dev": true,
             "dependencies": {
@@ -5291,13 +5291,13 @@
         },
         "node_modules/minimalistic-assert": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
             "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
             "dev": true
         },
         "node_modules/minimatch": {
             "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minimatch/-/minimatch-10.1.1.tgz",
             "integrity": "sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==",
             "dev": true,
             "license": "BlueOak-1.0.0",
@@ -5313,7 +5313,7 @@
         },
         "node_modules/minipass": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/minipass/-/minipass-7.1.2.tgz",
             "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
             "dev": true,
             "engines": {
@@ -5322,13 +5322,13 @@
         },
         "node_modules/ms": {
             "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
             "dev": true
         },
         "node_modules/multicast-dns": {
             "version": "7.2.5",
-            "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/multicast-dns/-/multicast-dns-7.2.5.tgz",
             "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
             "dev": true,
             "dependencies": {
@@ -5341,7 +5341,7 @@
         },
         "node_modules/nanoid": {
             "version": "3.3.8",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/nanoid/-/nanoid-3.3.8.tgz",
             "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "dev": true,
             "funding": [
@@ -5359,7 +5359,7 @@
         },
         "node_modules/negotiator": {
             "version": "0.6.4",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/negotiator/-/negotiator-0.6.4.tgz",
             "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
             "dev": true,
             "engines": {
@@ -5368,13 +5368,13 @@
         },
         "node_modules/neo-async": {
             "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/neo-async/-/neo-async-2.6.2.tgz",
             "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
             "dev": true
         },
         "node_modules/node-forge": {
             "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-forge/-/node-forge-1.3.2.tgz",
             "integrity": "sha512-6xKiQ+cph9KImrRh0VsjH2d8/GXA4FIMlgU4B757iI1ApvcyA9VlouP0yZJha01V+huImO+kKMU7ih+2+E14fw==",
             "dev": true,
             "license": "(BSD-3-Clause OR GPL-2.0)",
@@ -5384,13 +5384,13 @@
         },
         "node_modules/node-releases": {
             "version": "2.0.19",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/node-releases/-/node-releases-2.0.19.tgz",
             "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
             "dev": true
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
             "engines": {
@@ -5399,7 +5399,7 @@
         },
         "node_modules/object-assign": {
             "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object-assign/-/object-assign-4.1.1.tgz",
             "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
             "engines": {
                 "node": ">=0.10.0"
@@ -5407,7 +5407,7 @@
         },
         "node_modules/object-inspect": {
             "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object-inspect/-/object-inspect-1.13.3.tgz",
             "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
             "engines": {
                 "node": ">= 0.4"
@@ -5418,7 +5418,7 @@
         },
         "node_modules/object-keys": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object-keys/-/object-keys-1.1.1.tgz",
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
             "engines": {
                 "node": ">= 0.4"
@@ -5426,7 +5426,7 @@
         },
         "node_modules/object.assign": {
             "version": "4.1.7",
-            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/object.assign/-/object.assign-4.1.7.tgz",
             "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -5445,13 +5445,13 @@
         },
         "node_modules/obuf": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/obuf/-/obuf-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/obuf/-/obuf-1.1.2.tgz",
             "integrity": "sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==",
             "dev": true
         },
         "node_modules/on-finished": {
             "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/on-finished/-/on-finished-2.4.1.tgz",
             "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
             "dev": true,
             "dependencies": {
@@ -5463,7 +5463,7 @@
         },
         "node_modules/on-headers": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/on-headers/-/on-headers-1.1.0.tgz",
             "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
             "dev": true,
             "license": "MIT",
@@ -5473,7 +5473,7 @@
         },
         "node_modules/open": {
             "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/open/-/open-10.1.0.tgz",
             "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
             "dev": true,
             "dependencies": {
@@ -5491,7 +5491,7 @@
         },
         "node_modules/own-keys": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/own-keys/-/own-keys-1.0.1.tgz",
             "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
             "dependencies": {
                 "get-intrinsic": "^1.2.6",
@@ -5507,7 +5507,7 @@
         },
         "node_modules/p-limit": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
             "license": "MIT",
@@ -5523,7 +5523,7 @@
         },
         "node_modules/p-locate": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
             "license": "MIT",
@@ -5539,7 +5539,7 @@
         },
         "node_modules/p-retry": {
             "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-6.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-retry/-/p-retry-6.2.1.tgz",
             "integrity": "sha512-hEt02O4hUct5wtwg4H4KcWgDdm+l1bOaEy/hWzd8xtXB9BqxTWBBhb+2ImAtH4Cv4rPjV76xN3Zumqk3k3AhhQ==",
             "dev": true,
             "dependencies": {
@@ -5556,7 +5556,7 @@
         },
         "node_modules/p-try": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/p-try/-/p-try-2.2.0.tgz",
             "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
             "dev": true,
             "engines": {
@@ -5565,13 +5565,13 @@
         },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
             "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
             "dev": true
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/parseurl/-/parseurl-1.3.3.tgz",
             "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
             "dev": true,
             "engines": {
@@ -5580,7 +5580,7 @@
         },
         "node_modules/path-exists": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
             "license": "MIT",
@@ -5590,7 +5590,7 @@
         },
         "node_modules/path-key": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
             "engines": {
@@ -5599,13 +5599,13 @@
         },
         "node_modules/path-parse": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-parse/-/path-parse-1.0.7.tgz",
             "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
             "dev": true
         },
         "node_modules/path-scurry": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-scurry/-/path-scurry-2.0.0.tgz",
             "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
             "dev": true,
             "dependencies": {
@@ -5621,7 +5621,7 @@
         },
         "node_modules/path-scurry/node_modules/lru-cache": {
             "version": "11.0.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/lru-cache/-/lru-cache-11.0.2.tgz",
             "integrity": "sha512-123qHRfJBmo2jXDbo/a5YOQrJoHF/GNQTLzQ5+IdK5pWpceK17yRc6ozlWd25FxvGKQbIUs91fDFkXmDHTKcyA==",
             "dev": true,
             "engines": {
@@ -5630,19 +5630,19 @@
         },
         "node_modules/path-to-regexp": {
             "version": "0.1.12",
-            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
             "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
             "dev": true
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/picocolors/-/picocolors-1.1.1.tgz",
             "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
             "dev": true
         },
         "node_modules/picomatch": {
             "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
             "engines": {
@@ -5654,7 +5654,7 @@
         },
         "node_modules/possible-typed-array-names": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
             "integrity": "sha512-d7Uw+eZoloe0EHDIYoe+bQ5WXnGMOpmiZFTuMWCwpjzzkL2nTjcKiAk4hh8TjnGye2TwWOk3UXucZ+3rbmBa8Q==",
             "engines": {
                 "node": ">= 0.4"
@@ -5662,7 +5662,7 @@
         },
         "node_modules/postcss": {
             "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/postcss/-/postcss-8.5.1.tgz",
             "integrity": "sha512-6oz2beyjc5VMn/KV1pPw8fliQkhBXrVn1Z3TVyqZxU8kZpzEKhBdmCFqI6ZbmGtamQvQGuU1sgPTk8ZrXDD7jQ==",
             "dev": true,
             "funding": [
@@ -5690,7 +5690,7 @@
         },
         "node_modules/postcss-modules-extract-imports": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
             "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
             "dev": true,
             "engines": {
@@ -5702,7 +5702,7 @@
         },
         "node_modules/postcss-modules-local-by-default": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
             "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
             "dev": true,
             "dependencies": {
@@ -5719,7 +5719,7 @@
         },
         "node_modules/postcss-modules-scope": {
             "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
             "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
             "dev": true,
             "dependencies": {
@@ -5734,7 +5734,7 @@
         },
         "node_modules/postcss-modules-values": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
             "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
             "dev": true,
             "dependencies": {
@@ -5749,7 +5749,7 @@
         },
         "node_modules/postcss-selector-parser": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/postcss-selector-parser/-/postcss-selector-parser-7.0.0.tgz",
             "integrity": "sha512-9RbEr1Y7FFfptd/1eEdntyjMwLeghW1bHX9GWjXo19vx4ytPQhANltvVxDggzJl7mnWM+dX28kb6cyS/4iQjlQ==",
             "dev": true,
             "dependencies": {
@@ -5762,19 +5762,19 @@
         },
         "node_modules/postcss-value-parser": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
             "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
             "dev": true
         },
         "node_modules/process-nextick-args": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
             "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
         "node_modules/prop-types": {
             "version": "15.8.1",
-            "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
             "dependencies": {
                 "loose-envify": "^1.4.0",
@@ -5784,7 +5784,7 @@
         },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/proxy-addr/-/proxy-addr-2.0.7.tgz",
             "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
             "dev": true,
             "dependencies": {
@@ -5797,7 +5797,7 @@
         },
         "node_modules/proxy-addr/node_modules/ipaddr.js": {
             "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
             "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
             "dev": true,
             "engines": {
@@ -5806,7 +5806,7 @@
         },
         "node_modules/qs": {
             "version": "6.14.1",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/qs/-/qs-6.14.1.tgz",
             "integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
             "dev": true,
             "license": "BSD-3-Clause",
@@ -5822,7 +5822,7 @@
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
             "dev": true,
             "dependencies": {
@@ -5831,7 +5831,7 @@
         },
         "node_modules/range-parser": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/range-parser/-/range-parser-1.2.1.tgz",
             "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "dev": true,
             "engines": {
@@ -5840,7 +5840,7 @@
         },
         "node_modules/raw-body": {
             "version": "2.5.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/raw-body/-/raw-body-2.5.3.tgz",
             "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
             "dev": true,
             "license": "MIT",
@@ -5856,7 +5856,7 @@
         },
         "node_modules/raw-body/node_modules/http-errors": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-errors/-/http-errors-2.0.1.tgz",
             "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
             "dev": true,
             "license": "MIT",
@@ -5877,7 +5877,7 @@
         },
         "node_modules/raw-body/node_modules/statuses": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/statuses/-/statuses-2.0.2.tgz",
             "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
             "dev": true,
             "license": "MIT",
@@ -5887,7 +5887,7 @@
         },
         "node_modules/react": {
             "version": "16.14.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/react/-/react-16.14.0.tgz",
             "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -5900,7 +5900,7 @@
         },
         "node_modules/react-dom": {
             "version": "16.14.0",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/react-dom/-/react-dom-16.14.0.tgz",
             "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -5914,12 +5914,12 @@
         },
         "node_modules/react-is": {
             "version": "16.13.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/react-is/-/react-is-16.13.1.tgz",
             "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/react-refresh": {
             "version": "0.17.0",
-            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/react-refresh/-/react-refresh-0.17.0.tgz",
             "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
             "dev": true,
             "license": "MIT",
@@ -5929,7 +5929,7 @@
         },
         "node_modules/readable-stream": {
             "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/readable-stream/-/readable-stream-3.6.2.tgz",
             "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
             "dev": true,
             "dependencies": {
@@ -5943,7 +5943,7 @@
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/readdirp/-/readdirp-3.6.0.tgz",
             "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
             "dev": true,
             "dependencies": {
@@ -5955,7 +5955,7 @@
         },
         "node_modules/rechoir": {
             "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.8.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rechoir/-/rechoir-0.8.0.tgz",
             "integrity": "sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==",
             "dev": true,
             "dependencies": {
@@ -5967,7 +5967,7 @@
         },
         "node_modules/reflect.getprototypeof": {
             "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
             "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -5988,13 +5988,13 @@
         },
         "node_modules/regenerate": {
             "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/regenerate/-/regenerate-1.4.2.tgz",
             "integrity": "sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==",
             "dev": true
         },
         "node_modules/regenerate-unicode-properties": {
             "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
             "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
             "dev": true,
             "dependencies": {
@@ -6006,7 +6006,7 @@
         },
         "node_modules/regexp.prototype.flags": {
             "version": "1.5.4",
-            "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
             "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -6025,7 +6025,7 @@
         },
         "node_modules/regexpu-core": {
             "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-6.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/regexpu-core/-/regexpu-core-6.2.0.tgz",
             "integrity": "sha512-H66BPQMrv+V16t8xtmq+UC0CBpiTBA60V8ibS1QVReIp8T1z8hwFxqcGzm9K6lgsN7sB5edVH8a+ze6Fqm4weA==",
             "dev": true,
             "dependencies": {
@@ -6042,13 +6042,13 @@
         },
         "node_modules/regjsgen": {
             "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.8.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/regjsgen/-/regjsgen-0.8.0.tgz",
             "integrity": "sha512-RvwtGe3d7LvWiDQXeQw8p5asZUmfU1G/l6WbUXeHta7Y2PEIvBTwH6E2EfmYUK8pxcxEdEmaomqyp0vZZ7C+3Q==",
             "dev": true
         },
         "node_modules/regjsparser": {
             "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.12.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/regjsparser/-/regjsparser-0.12.0.tgz",
             "integrity": "sha512-cnE+y8bz4NhMjISKbgeVJtqNbtf5QpjZP+Bslo+UqkIt9QPnX9q095eiRRASJG1/tz6dlNr6Z5NsBiWYokp6EQ==",
             "dev": true,
             "dependencies": {
@@ -6060,7 +6060,7 @@
         },
         "node_modules/regjsparser/node_modules/jsesc": {
             "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/jsesc/-/jsesc-3.0.2.tgz",
             "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
             "dev": true,
             "bin": {
@@ -6072,7 +6072,7 @@
         },
         "node_modules/require-from-string": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
             "dev": true,
             "engines": {
@@ -6081,13 +6081,13 @@
         },
         "node_modules/requires-port": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/requires-port/-/requires-port-1.0.0.tgz",
             "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
             "dev": true
         },
         "node_modules/resolve": {
             "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve/-/resolve-1.22.10.tgz",
             "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
             "dev": true,
             "dependencies": {
@@ -6107,7 +6107,7 @@
         },
         "node_modules/resolve-cwd": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
             "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
             "dev": true,
             "dependencies": {
@@ -6119,7 +6119,7 @@
         },
         "node_modules/resolve-from": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
             "dev": true,
             "engines": {
@@ -6128,7 +6128,7 @@
         },
         "node_modules/retry": {
             "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/retry/-/retry-0.13.1.tgz",
             "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
             "dev": true,
             "engines": {
@@ -6137,7 +6137,7 @@
         },
         "node_modules/rimraf": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/rimraf/-/rimraf-6.0.1.tgz",
             "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
             "dev": true,
             "dependencies": {
@@ -6156,7 +6156,7 @@
         },
         "node_modules/run-applescript": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/run-applescript/-/run-applescript-7.0.0.tgz",
             "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
             "dev": true,
             "engines": {
@@ -6168,7 +6168,7 @@
         },
         "node_modules/safe-array-concat": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
             "integrity": "sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -6186,12 +6186,12 @@
         },
         "node_modules/safe-array-concat/node_modules/isarray": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/safe-buffer": {
             "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-buffer/-/safe-buffer-5.2.1.tgz",
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
             "dev": true,
             "funding": [
@@ -6211,7 +6211,7 @@
         },
         "node_modules/safe-push-apply": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
             "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -6226,12 +6226,12 @@
         },
         "node_modules/safe-push-apply/node_modules/isarray": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/safe-regex-test": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
             "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -6247,14 +6247,14 @@
         },
         "node_modules/safer-buffer": {
             "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/scheduler": {
             "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/scheduler/-/scheduler-0.19.1.tgz",
             "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
             "dependencies": {
                 "loose-envify": "^1.1.0",
@@ -6263,7 +6263,7 @@
         },
         "node_modules/schema-utils": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/schema-utils/-/schema-utils-4.3.2.tgz",
             "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
             "dev": true,
             "license": "MIT",
@@ -6283,13 +6283,13 @@
         },
         "node_modules/select-hose": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/select-hose/-/select-hose-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/select-hose/-/select-hose-2.0.0.tgz",
             "integrity": "sha512-mEugaLK+YfkijB4fx0e6kImuJdCIt2LxCRcbEYPqRGCs4F2ogyfZU5IAZRdjCP8JPq2AtdNoC/Dux63d9Kiryg==",
             "dev": true
         },
         "node_modules/selfsigned": {
             "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/selfsigned/-/selfsigned-2.4.1.tgz",
             "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
             "dev": true,
             "dependencies": {
@@ -6302,7 +6302,7 @@
         },
         "node_modules/semver": {
             "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-6.3.1.tgz",
             "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
             "dev": true,
             "bin": {
@@ -6311,7 +6311,7 @@
         },
         "node_modules/send": {
             "version": "0.19.0",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/send/-/send-0.19.0.tgz",
             "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
             "dev": true,
             "dependencies": {
@@ -6335,7 +6335,7 @@
         },
         "node_modules/send/node_modules/debug": {
             "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "dependencies": {
@@ -6344,13 +6344,13 @@
         },
         "node_modules/send/node_modules/debug/node_modules/ms": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/send/node_modules/encodeurl": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
             "dev": true,
             "engines": {
@@ -6359,7 +6359,7 @@
         },
         "node_modules/serialize-javascript": {
             "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
             "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
             "dev": true,
             "dependencies": {
@@ -6368,7 +6368,7 @@
         },
         "node_modules/serve-index": {
             "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/serve-index/-/serve-index-1.9.1.tgz",
             "integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
             "dev": true,
             "dependencies": {
@@ -6386,7 +6386,7 @@
         },
         "node_modules/serve-index/node_modules/debug": {
             "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/debug/-/debug-2.6.9.tgz",
             "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
             "dev": true,
             "dependencies": {
@@ -6395,7 +6395,7 @@
         },
         "node_modules/serve-index/node_modules/depd": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/depd/-/depd-1.1.2.tgz",
             "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
             "dev": true,
             "engines": {
@@ -6404,7 +6404,7 @@
         },
         "node_modules/serve-index/node_modules/http-errors": {
             "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/http-errors/-/http-errors-1.6.3.tgz",
             "integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
             "dev": true,
             "dependencies": {
@@ -6419,25 +6419,25 @@
         },
         "node_modules/serve-index/node_modules/inherits": {
             "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/inherits/-/inherits-2.0.3.tgz",
             "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
             "dev": true
         },
         "node_modules/serve-index/node_modules/ms": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ms/-/ms-2.0.0.tgz",
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true
         },
         "node_modules/serve-index/node_modules/setprototypeof": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/setprototypeof/-/setprototypeof-1.1.0.tgz",
             "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
             "dev": true
         },
         "node_modules/serve-index/node_modules/statuses": {
             "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/statuses/-/statuses-1.5.0.tgz",
             "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
             "dev": true,
             "engines": {
@@ -6446,7 +6446,7 @@
         },
         "node_modules/serve-static": {
             "version": "1.16.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/serve-static/-/serve-static-1.16.2.tgz",
             "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
             "dev": true,
             "dependencies": {
@@ -6461,7 +6461,7 @@
         },
         "node_modules/set-function-length": {
             "version": "1.2.2",
-            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/set-function-length/-/set-function-length-1.2.2.tgz",
             "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
             "dependencies": {
                 "define-data-property": "^1.1.4",
@@ -6477,7 +6477,7 @@
         },
         "node_modules/set-function-name": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/set-function-name/-/set-function-name-2.0.2.tgz",
             "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
             "dependencies": {
                 "define-data-property": "^1.1.4",
@@ -6491,7 +6491,7 @@
         },
         "node_modules/set-proto": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/set-proto/-/set-proto-1.0.0.tgz",
             "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
             "dependencies": {
                 "dunder-proto": "^1.0.1",
@@ -6504,13 +6504,13 @@
         },
         "node_modules/setprototypeof": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/setprototypeof/-/setprototypeof-1.2.0.tgz",
             "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
             "dev": true
         },
         "node_modules/shallow-clone": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shallow-clone/-/shallow-clone-3.0.1.tgz",
             "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
             "dev": true,
             "dependencies": {
@@ -6522,7 +6522,7 @@
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
             "dependencies": {
@@ -6534,7 +6534,7 @@
         },
         "node_modules/shebang-regex": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
             "engines": {
@@ -6543,7 +6543,7 @@
         },
         "node_modules/shell-quote": {
             "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/shell-quote/-/shell-quote-1.8.2.tgz",
             "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
             "dev": true,
             "engines": {
@@ -6555,7 +6555,7 @@
         },
         "node_modules/side-channel": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel/-/side-channel-1.1.0.tgz",
             "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -6573,7 +6573,7 @@
         },
         "node_modules/side-channel-list": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-list/-/side-channel-list-1.0.0.tgz",
             "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -6588,7 +6588,7 @@
         },
         "node_modules/side-channel-map": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-map/-/side-channel-map-1.0.1.tgz",
             "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -6605,7 +6605,7 @@
         },
         "node_modules/side-channel-weakmap": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
             "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -6623,7 +6623,7 @@
         },
         "node_modules/signal-exit": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/signal-exit/-/signal-exit-4.1.0.tgz",
             "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
             "dev": true,
             "engines": {
@@ -6635,7 +6635,7 @@
         },
         "node_modules/sockjs": {
             "version": "0.3.24",
-            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.24.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/sockjs/-/sockjs-0.3.24.tgz",
             "integrity": "sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==",
             "dev": true,
             "dependencies": {
@@ -6646,7 +6646,7 @@
         },
         "node_modules/source-map": {
             "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/source-map/-/source-map-0.7.4.tgz",
             "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
             "dev": true,
             "engines": {
@@ -6655,7 +6655,7 @@
         },
         "node_modules/source-map-js": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/source-map-js/-/source-map-js-1.2.1.tgz",
             "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
             "dev": true,
             "engines": {
@@ -6664,7 +6664,7 @@
         },
         "node_modules/source-map-support": {
             "version": "0.5.21",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/source-map-support/-/source-map-support-0.5.21.tgz",
             "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
             "dev": true,
             "dependencies": {
@@ -6674,7 +6674,7 @@
         },
         "node_modules/source-map-support/node_modules/source-map": {
             "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/source-map/-/source-map-0.6.1.tgz",
             "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
             "dev": true,
             "engines": {
@@ -6683,7 +6683,7 @@
         },
         "node_modules/spdy": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/spdy/-/spdy-4.0.2.tgz",
             "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
             "dev": true,
             "dependencies": {
@@ -6699,7 +6699,7 @@
         },
         "node_modules/spdy-transport": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-3.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/spdy-transport/-/spdy-transport-3.0.0.tgz",
             "integrity": "sha512-hsLVFE5SjA6TCisWeJXFKniGGOpBgMLmerfO2aCyCU5s7nJ/rpAepqmFifv/GCbSbueEeAJJnmSQ2rKC/g8Fcw==",
             "dev": true,
             "dependencies": {
@@ -6713,13 +6713,13 @@
         },
         "node_modules/stackframe": {
             "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/stackframe/-/stackframe-1.3.4.tgz",
             "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
             "dev": true
         },
         "node_modules/statuses": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/statuses/-/statuses-2.0.1.tgz",
             "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
             "dev": true,
             "engines": {
@@ -6728,7 +6728,7 @@
         },
         "node_modules/string_decoder": {
             "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string_decoder/-/string_decoder-1.3.0.tgz",
             "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
             "dev": true,
             "dependencies": {
@@ -6737,7 +6737,7 @@
         },
         "node_modules/string-width": {
             "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-5.1.2.tgz",
             "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
             "dev": true,
             "license": "MIT",
@@ -6756,7 +6756,7 @@
         "node_modules/string-width-cjs": {
             "name": "string-width",
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
@@ -6771,7 +6771,7 @@
         },
         "node_modules/string-width-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -6781,14 +6781,14 @@
         },
         "node_modules/string-width-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/string-width-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -6801,37 +6801,37 @@
         },
         "node_modules/string.fromcodepoint": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.fromcodepoint/-/string.fromcodepoint-0.2.1.tgz",
             "integrity": "sha512-n69H31OnxSGSZyZbgBlvYIXlrMhJQ0dQAX1js1QDhpaUH6zmU3QYlj07bCwCNlPOu3oRXIubGPl2gDGnHsiCqg=="
         },
         "node_modules/string.prototype.codepointat": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
             "integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="
         },
         "node_modules/string.prototype.endswith": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.endswith/-/string.prototype.endswith-0.2.0.tgz",
             "integrity": "sha512-CLb+YN1AleXLWyh88P1R5s2ajz83wF6bWOyxfOXJ7P3ioK/lOnA39VIEcen24/ELWJvU6y8NG6vEmWSOJIVFfQ=="
         },
         "node_modules/string.prototype.includes": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.includes/-/string.prototype.includes-1.0.0.tgz",
             "integrity": "sha512-CQISPErVwGVgZhM12HCHg9/5XR4LZBhB/dQVvA64g4q/X17TM5Q54NxEj10EBHyy85s601S8qp3y63ZGvs5GAg=="
         },
         "node_modules/string.prototype.repeat": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
             "integrity": "sha512-1BH+X+1hSthZFW+X+JaUkjkkUPwIlLEMJBLANN3hOob3RhEk5snLWNECDnYbgn/m5c5JV7Ersu1Yubaf+05cIA=="
         },
         "node_modules/string.prototype.startswith": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.startswith/-/string.prototype.startswith-0.2.0.tgz",
             "integrity": "sha512-4Rj/0GFJbva6TUkI5gC/MOwJrcY19CvgIAqLlTpKhGJVoHiWtXh5UWSX9uGE3Es4eUhFSoWJ0RVCt9j3QcK7IQ=="
         },
         "node_modules/string.prototype.trim": {
             "version": "1.2.10",
-            "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trim/-/string.prototype.trim-1.2.10.tgz",
             "integrity": "sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -6851,7 +6851,7 @@
         },
         "node_modules/string.prototype.trimend": {
             "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trimend/-/string.prototype.trimend-1.0.9.tgz",
             "integrity": "sha512-G7Ok5C6E/j4SGfyLCloXTrngQIQU3PWtXGst3yM7Bea9FRURf1S42ZHlZZtsNque2FN2PoUhfZXYLNWwEr4dLQ==",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -6868,7 +6868,7 @@
         },
         "node_modules/string.prototype.trimstart": {
             "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
             "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -6884,7 +6884,7 @@
         },
         "node_modules/strip-ansi": {
             "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-7.1.2.tgz",
             "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
             "dev": true,
             "license": "MIT",
@@ -6901,7 +6901,7 @@
         "node_modules/strip-ansi-cjs": {
             "name": "strip-ansi",
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -6914,7 +6914,7 @@
         },
         "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -6924,7 +6924,7 @@
         },
         "node_modules/style-loader": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-4.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/style-loader/-/style-loader-4.0.0.tgz",
             "integrity": "sha512-1V4WqhhZZgjVAVJyt7TdDPZoPBPNHbekX4fWnCJL1yQukhCeZhJySUL+gL9y6sNdN95uEOS83Y55SqHcP7MzLA==",
             "dev": true,
             "engines": {
@@ -6940,7 +6940,7 @@
         },
         "node_modules/supports-color": {
             "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
             "dependencies": {
@@ -6952,7 +6952,7 @@
         },
         "node_modules/supports-preserve-symlinks-flag": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
             "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
             "dev": true,
             "engines": {
@@ -6964,7 +6964,7 @@
         },
         "node_modules/tapable": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tapable/-/tapable-2.2.1.tgz",
             "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
             "dev": true,
             "engines": {
@@ -6973,7 +6973,7 @@
         },
         "node_modules/terser": {
             "version": "5.37.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.37.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/terser/-/terser-5.37.0.tgz",
             "integrity": "sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==",
             "dev": true,
             "dependencies": {
@@ -6991,7 +6991,7 @@
         },
         "node_modules/terser-webpack-plugin": {
             "version": "5.3.11",
-            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/terser-webpack-plugin/-/terser-webpack-plugin-5.3.11.tgz",
             "integrity": "sha512-RVCsMfuD0+cTt3EwX8hSl2Ks56EbFHWmhluwcqoPKtBnfjiT6olaq7PRIRfhyU8nnC2MrnDrBLfrD/RGE+cVXQ==",
             "dev": true,
             "dependencies": {
@@ -7025,7 +7025,7 @@
         },
         "node_modules/thingies": {
             "version": "1.21.0",
-            "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/thingies/-/thingies-1.21.0.tgz",
             "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
             "dev": true,
             "engines": {
@@ -7037,13 +7037,13 @@
         },
         "node_modules/thunky": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/thunky/-/thunky-1.1.0.tgz",
             "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
             "dev": true
         },
         "node_modules/tinyglobby": {
             "version": "0.2.14",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tinyglobby/-/tinyglobby-0.2.14.tgz",
             "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
             "dev": true,
             "license": "MIT",
@@ -7060,7 +7060,7 @@
         },
         "node_modules/tinyglobby/node_modules/fdir": {
             "version": "6.4.5",
-            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/fdir/-/fdir-6.4.5.tgz",
             "integrity": "sha512-4BG7puHpVsIYxZUbiUE3RqGloLaSSwzYie5jvasC4LWuBWzZawynvYouhjbQKw2JuIGYdm0DzIxl8iVidKlUEw==",
             "dev": true,
             "license": "MIT",
@@ -7075,7 +7075,7 @@
         },
         "node_modules/tinyglobby/node_modules/picomatch": {
             "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/picomatch/-/picomatch-4.0.2.tgz",
             "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
             "dev": true,
             "license": "MIT",
@@ -7088,7 +7088,7 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
             "dependencies": {
@@ -7100,7 +7100,7 @@
         },
         "node_modules/toidentifier": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/toidentifier/-/toidentifier-1.0.1.tgz",
             "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
             "dev": true,
             "engines": {
@@ -7109,7 +7109,7 @@
         },
         "node_modules/tree-dump": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tree-dump/-/tree-dump-1.0.2.tgz",
             "integrity": "sha512-dpev9ABuLWdEubk+cIaI9cHwRNNDjkBBLXTwI4UCUFdQ5xXKqNXoK4FEciw/vxf+NQ7Cb7sGUyeUtORvHIdRXQ==",
             "dev": true,
             "engines": {
@@ -7125,7 +7125,7 @@
         },
         "node_modules/ts-loader": {
             "version": "9.5.2",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ts-loader/-/ts-loader-9.5.2.tgz",
             "integrity": "sha512-Qo4piXvOTWcMGIgRiuFa6nHNm+54HbYaZCKqc9eeZCLRy3XqafQgwX2F7mofrbJG3g7EEb+lkiR+z2Lic2s3Zw==",
             "dev": true,
             "dependencies": {
@@ -7145,7 +7145,7 @@
         },
         "node_modules/ts-loader/node_modules/semver": {
             "version": "7.7.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/semver/-/semver-7.7.0.tgz",
             "integrity": "sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==",
             "dev": true,
             "bin": {
@@ -7157,13 +7157,13 @@
         },
         "node_modules/tslib": {
             "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true
         },
         "node_modules/type-is": {
             "version": "1.6.18",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/type-is/-/type-is-1.6.18.tgz",
             "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
             "dev": true,
             "dependencies": {
@@ -7176,7 +7176,7 @@
         },
         "node_modules/typed-array-buffer": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
             "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -7189,7 +7189,7 @@
         },
         "node_modules/typed-array-byte-length": {
             "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
             "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
             "dependencies": {
                 "call-bind": "^1.0.8",
@@ -7207,7 +7207,7 @@
         },
         "node_modules/typed-array-byte-offset": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
             "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
@@ -7227,7 +7227,7 @@
         },
         "node_modules/typed-array-length": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.7.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typed-array-length/-/typed-array-length-1.0.7.tgz",
             "integrity": "sha512-3KS2b+kL7fsuk/eJZ7EQdnEmQoaho/r6KUef7hxvltNA5DR8NAUM+8wJMbJyZ4G9/7i3v5zPBIMN5aybAh2/Jg==",
             "dependencies": {
                 "call-bind": "^1.0.7",
@@ -7246,7 +7246,7 @@
         },
         "node_modules/typescript": {
             "version": "5.9.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/typescript/-/typescript-5.9.2.tgz",
             "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
             "dev": true,
             "license": "Apache-2.0",
@@ -7260,7 +7260,7 @@
         },
         "node_modules/unbox-primitive": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
             "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
             "dependencies": {
                 "call-bound": "^1.0.3",
@@ -7277,13 +7277,13 @@
         },
         "node_modules/undici-types": {
             "version": "6.20.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/undici-types/-/undici-types-6.20.0.tgz",
             "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
             "dev": true
         },
         "node_modules/unicode-canonical-property-names-ecmascript": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
             "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
             "dev": true,
             "engines": {
@@ -7292,7 +7292,7 @@
         },
         "node_modules/unicode-match-property-ecmascript": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-2.0.0.tgz",
             "integrity": "sha512-5kaZCrbp5mmbz5ulBkDkbY0SsPOjKqVS35VpL9ulMPfSl0J0Xsm+9Evphv9CoIZFwre7aJoa94AY6seMKGVN5Q==",
             "dev": true,
             "dependencies": {
@@ -7305,7 +7305,7 @@
         },
         "node_modules/unicode-match-property-value-ecmascript": {
             "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
             "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
             "dev": true,
             "engines": {
@@ -7314,7 +7314,7 @@
         },
         "node_modules/unicode-property-aliases-ecmascript": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
             "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
             "dev": true,
             "engines": {
@@ -7323,7 +7323,7 @@
         },
         "node_modules/unpipe": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/unpipe/-/unpipe-1.0.0.tgz",
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "dev": true,
             "engines": {
@@ -7332,7 +7332,7 @@
         },
         "node_modules/update-browserslist-db": {
             "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
             "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
             "dev": true,
             "funding": [
@@ -7363,13 +7363,13 @@
         },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/util-deprecate/-/util-deprecate-1.0.2.tgz",
             "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
             "dev": true
         },
         "node_modules/utils-merge": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/utils-merge/-/utils-merge-1.0.1.tgz",
             "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
             "dev": true,
             "engines": {
@@ -7378,7 +7378,7 @@
         },
         "node_modules/uuid": {
             "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/uuid/-/uuid-8.3.2.tgz",
             "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
             "dev": true,
             "bin": {
@@ -7387,7 +7387,7 @@
         },
         "node_modules/vary": {
             "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/vary/-/vary-1.1.2.tgz",
             "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
             "dev": true,
             "engines": {
@@ -7396,7 +7396,7 @@
         },
         "node_modules/watchpack": {
             "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/watchpack/-/watchpack-2.4.2.tgz",
             "integrity": "sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==",
             "dev": true,
             "dependencies": {
@@ -7409,7 +7409,7 @@
         },
         "node_modules/wbuf": {
             "version": "1.7.3",
-            "resolved": "https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wbuf/-/wbuf-1.7.3.tgz",
             "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
             "dev": true,
             "dependencies": {
@@ -7418,7 +7418,7 @@
         },
         "node_modules/webpack": {
             "version": "5.101.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.101.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack/-/webpack-5.101.0.tgz",
             "integrity": "sha512-B4t+nJqytPeuZlHuIKTbalhljIFXeNRqrUGAQgTGlfOl2lXXKXw+yZu6bicycP+PUlM44CxBjCFD6aciKFT3LQ==",
             "dev": true,
             "license": "MIT",
@@ -7467,7 +7467,7 @@
         },
         "node_modules/webpack-cli": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack-cli/-/webpack-cli-6.0.1.tgz",
             "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
             "dev": true,
             "dependencies": {
@@ -7509,7 +7509,7 @@
         },
         "node_modules/webpack-cli/node_modules/commander": {
             "version": "12.1.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/commander/-/commander-12.1.0.tgz",
             "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
             "dev": true,
             "engines": {
@@ -7518,7 +7518,7 @@
         },
         "node_modules/webpack-dev-middleware": {
             "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack-dev-middleware/-/webpack-dev-middleware-7.4.2.tgz",
             "integrity": "sha512-xOO8n6eggxnwYpy1NlzUKpvrjfJTvae5/D6WOK0S2LSo7vjmo5gCM1DbLUmFqrMTJP+W/0YZNctm7jasWvLuBA==",
             "dev": true,
             "dependencies": {
@@ -7547,7 +7547,7 @@
         },
         "node_modules/webpack-dev-server": {
             "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
             "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
             "dev": true,
             "license": "MIT",
@@ -7605,7 +7605,7 @@
         },
         "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
             "version": "4.19.6",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
             "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
             "dev": true,
             "license": "MIT",
@@ -7618,7 +7618,7 @@
         },
         "node_modules/webpack-merge": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack-merge/-/webpack-merge-6.0.1.tgz",
             "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
             "dev": true,
             "dependencies": {
@@ -7632,7 +7632,7 @@
         },
         "node_modules/webpack-sources": {
             "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/webpack-sources/-/webpack-sources-3.3.3.tgz",
             "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
             "dev": true,
             "license": "MIT",
@@ -7642,7 +7642,7 @@
         },
         "node_modules/websocket-driver": {
             "version": "0.7.4",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/websocket-driver/-/websocket-driver-0.7.4.tgz",
             "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
             "dev": true,
             "dependencies": {
@@ -7656,7 +7656,7 @@
         },
         "node_modules/websocket-extensions": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
             "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "dev": true,
             "engines": {
@@ -7665,12 +7665,12 @@
         },
         "node_modules/whatwg-fetch": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/whatwg-fetch/-/whatwg-fetch-3.0.1.tgz",
             "integrity": "sha512-gPeS9Ef8bSigQwAZiSbQyyU/sBQP1Qo6r112A2shGw5B6+4YT1D8O0oXXwF3zgXXLrrfxbIeP8fM3JmsoWU4Vw=="
         },
         "node_modules/which": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
             "dependencies": {
@@ -7685,7 +7685,7 @@
         },
         "node_modules/which-boxed-primitive": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
             "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
             "dependencies": {
                 "is-bigint": "^1.1.0",
@@ -7703,7 +7703,7 @@
         },
         "node_modules/which-builtin-type": {
             "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
             "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
             "dependencies": {
                 "call-bound": "^1.0.2",
@@ -7729,12 +7729,12 @@
         },
         "node_modules/which-builtin-type/node_modules/isarray": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/isarray/-/isarray-2.0.5.tgz",
             "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
         },
         "node_modules/which-collection": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which-collection/-/which-collection-1.0.2.tgz",
             "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
             "dependencies": {
                 "is-map": "^2.0.3",
@@ -7751,7 +7751,7 @@
         },
         "node_modules/which-typed-array": {
             "version": "1.1.18",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/which-typed-array/-/which-typed-array-1.1.18.tgz",
             "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.7",
@@ -7770,13 +7770,13 @@
         },
         "node_modules/wildcard": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/wildcard/-/wildcard-2.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wildcard/-/wildcard-2.0.1.tgz",
             "integrity": "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==",
             "dev": true
         },
         "node_modules/wrap-ansi": {
             "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
             "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
             "dev": true,
             "license": "MIT",
@@ -7795,7 +7795,7 @@
         "node_modules/wrap-ansi-cjs": {
             "name": "wrap-ansi",
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
             "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
             "dev": true,
             "license": "MIT",
@@ -7813,7 +7813,7 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
             "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
             "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
             "dev": true,
             "license": "MIT",
@@ -7823,14 +7823,14 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
             "version": "8.0.0",
-            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true,
             "license": "MIT"
         },
         "node_modules/wrap-ansi-cjs/node_modules/string-width": {
             "version": "4.2.3",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/string-width/-/string-width-4.2.3.tgz",
             "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
             "dev": true,
             "license": "MIT",
@@ -7845,7 +7845,7 @@
         },
         "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
             "dev": true,
             "license": "MIT",
@@ -7858,7 +7858,7 @@
         },
         "node_modules/wrap-ansi/node_modules/ansi-styles": {
             "version": "6.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ansi-styles/-/ansi-styles-6.2.3.tgz",
             "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
             "dev": true,
             "license": "MIT",
@@ -7871,7 +7871,7 @@
         },
         "node_modules/ws": {
             "version": "8.18.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/ws/-/ws-8.18.0.tgz",
             "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
             "dev": true,
             "engines": {
@@ -7892,13 +7892,13 @@
         },
         "node_modules/yallist": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yallist/-/yallist-3.1.1.tgz",
             "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
             "dev": true
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+            "resolved": "https://packagefeedproxy.microsoft.io/npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
             "license": "MIT",


### PR DESCRIPTION
## Summary
Resolves security alerts caused by direct access to npmjs.org.

## Changes
- Added .npmrc at repo root with proxy registry:
  `registry=https://packagefeedproxy.microsoft.io/npm/`
- Updated all package-lock.json resolved URLs from egistry.npmjs.org to packagefeedproxy.microsoft.io/npm (host-only change, identical path structure).

## Verification
Run `npm ci` to verify packages resolve correctly through the proxy.